### PR TITLE
🛡️ Sentinel: [Medium] Fix insecure shell interpolation in jq filters

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -26,3 +26,7 @@
 **Vulnerability:** Scripts derived local directory names from the `owner/repo` repository specification without checking for `..` components. An entry like `owner/repo/..` would cause the script to target the parent directory.
 **Learning:** Validating explicit "target directory" arguments is insufficient if other parts of the input (like the repository name) are also used to construct file paths. Attackers will use the least-validated field to achieve the same traversal.
 **Prevention:** Apply strict `..` validation to ALL user-provided tokens that contribute to path construction, including repository specifications, even if they are primarily intended as URLs or identifiers.
+## 2027-02-28 - [Medium] Insecure Shell Interpolation in jq Filters
+**Vulnerability:** Shell variables were interpolated directly into `jq` filter strings (e.g., `jq -r ".${field}"` or `if "'"$PERMISSIONS"'" == "all"`), potentially leading to injection vulnerabilities.
+**Learning:** Interpolating shell variables into `jq` filters is insecure as it allows the variable content to be parsed as part of the filter logic. Simple replacement with `.[$field]` also fails for nested paths (e.g., `commit.sha`).
+**Prevention:** Always use `jq`'s `--arg` or `--argjson` flags to pass values into the `jq` environment. For dynamic field access that may include nested paths, use `getpath($field | split("."))` to safely traverse the object.

--- a/scripts/helper/codespaces-auth-add.sh
+++ b/scripts/helper/codespaces-auth-add.sh
@@ -367,13 +367,13 @@ build_jq_array(){
 # ——— Generate the per-repo permissions object via jq —————————————
 build_jq_obj(){
   local arr_json="$1"
-  jq -n --argjson arr "$arr_json" '
+  jq -n --argjson arr "$arr_json" --arg perms "$PERMISSIONS" '
     reduce $arr[] as $repo ({}; 
       . + {
         ($repo): (
-          if "'"$PERMISSIONS"'" == "all" then
+          if $perms == "all" then
             { permissions:"write-all" }
-          elif "'"$PERMISSIONS"'" == "contents" then
+          elif $perms == "contents" then
             { permissions:{ contents:"write" } }
           else
             {

--- a/scripts/helper/create-repos.sh
+++ b/scripts/helper/create-repos.sh
@@ -208,7 +208,8 @@ validate_token() {
 # ── Helpers for branch creation ────────────────────────────────────────────────
 api_get_field() {
   local url="$1"; local field="$2"
-  curl -s -H "$AUTH_HDR" "$url" | jq -r ".${field}"
+  # Use getpath with split to support nested fields (e.g. "commit.sha") securely
+  curl -s -H "$AUTH_HDR" "$url" | jq -r --arg field "$field" 'getpath($field | split("."))'
 }
 
 create_branch() {


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Shell variables were interpolated directly into `jq` filter strings in `codespaces-auth-add.sh` and `create-repos.sh`.
🎯 Impact: Malicious variable content could alter `jq` filter logic, leading to "jq injection" and potential unauthorized data access or execution flow changes.
🔧 Fix: Replaced shell interpolation with `jq`'s `--arg` flag for safe variable passing. In `create-repos.sh`, used `getpath($field | split("."))` to robustly and securely support nested field paths (e.g., "commit.sha").
✅ Verification: Verified correct functionality and security fix by running `tests/test-codespaces-auth.sh`, `tests/test-setup-repos-local.sh`, and `tests/test-create-repos-fallback.sh`. Added a manual test case to confirm nested path resolution.

---
*PR created automatically by Jules for task [1307088738851281879](https://jules.google.com/task/1307088738851281879) started by @MiguelRodo*