### PR TITLE
🧹 Remove unused os import from Python tests

### DIFF
--- a/tests/test-python-wrappers.py
+++ b/tests/test-python-wrappers.py
@@ -2,7 +2,6 @@
 """Test Python wrapper functions with idiomatic syntax"""
 
 import sys
-import os
 from pathlib import Path
 
 # Add src to path to import repos module


### PR DESCRIPTION
🎯 **What:** Removed the unused `os` module import from `tests/test-python-wrappers.py`.
💡 **Why:** Improving code maintainability and readability by removing dead code.
✅ **Verification:** Ran `python3 tests/test-python-wrappers.py` and key Bash integration tests. All passed.
✨ **Result:** Cleaned up the test file by removing an unnecessary dependency.

---
*PR created automatically by Jules for task [9834454902255397380](https://jules.google.com/task/9834454902255397380) started by @MiguelRodo*