### PR TITLE
🛡️ Sentinel: Harden scripts against glob expansion and argument injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -35,3 +35,8 @@
 **Vulnerability:** Git commands like `git clone`, `git worktree add`, and `git push` were invoked with user-provided or variable-based arguments (e.g., branch names or repository URLs) without the `--` separator. This allowed an attacker to inject command-line flags (e.g., using a branch name like `-h`).
 **Learning:** Positional arguments that start with a hyphen can be interpreted as options by many Unix commands, including Git. Relying on variable expansion without termination of option parsing is a common source of argument injection.
 **Prevention:** Always use the `--` separator to terminate option parsing before passing positional arguments that may be user-controlled or contain arbitrary strings. Example: `git worktree add -- "$DEST" "$BRANCH"`.
+
+## 2027-03-01 - [Medium] Unintentional Glob Expansion in Shell Word-Splitting
+**Vulnerability:** User-provided strings from `repos.list` were word-split into positional parameters using `set -- $line` without disabling globbing. An entry like `*` would expand to the list of files in the current directory.
+**Learning:** Shell word-splitting (unquoted variable expansion) performs both field splitting and filename expansion (globbing) by default. This can lead to unexpected script behavior, incorrect configuration, or information leakage if the input contains glob characters.
+**Prevention:** Always disable globbing with `set -f` (noglob) before performing word-splitting on variables that might contain glob characters, and restore it with `set +f` afterwards if needed.

--- a/scripts/add-branch.sh
+++ b/scripts/add-branch.sh
@@ -138,10 +138,10 @@ fi
 # Check if branch exists on origin
 git fetch origin >/dev/null 2>&1 || true
 
-if git ls-remote --exit-code --heads origin "$BRANCH_NAME" >/dev/null 2>&1; then
+if git ls-remote --exit-code --heads origin -- "$BRANCH_NAME" >/dev/null 2>&1; then
   echo "Branch exists on origin, creating tracking worktree..."
   # Ensure we have the remote tracking branch
-  git fetch origin "refs/heads/$BRANCH_NAME:refs/remotes/origin/$BRANCH_NAME" 2>/dev/null || true
+  git fetch origin -- "refs/heads/$BRANCH_NAME:refs/remotes/origin/$BRANCH_NAME" 2>/dev/null || true
   git worktree add -b "$BRANCH_NAME" -- "$DEST" "origin/$BRANCH_NAME" || \
     git worktree add -- "$DEST" "$BRANCH_NAME"
 else

--- a/scripts/helper/clone-repos.sh
+++ b/scripts/helper/clone-repos.sh
@@ -868,7 +868,7 @@ create_worktree_for_branch() {
     else
       git -C "$dest" push -u origin -- HEAD:"$branch" || true
     fi
-  elif git -C "$base" ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+  elif git -C "$base" ls-remote --exit-code --heads origin -- "$branch" >/dev/null 2>&1; then
     echo "Branch exists: $branch (on remote)"
     [[ "$debug" == true ]] && echo "create_worktree_for_branch: branch exists on origin, tracking it" >&2
     echo "Adding worktree $dest (tracking origin/$branch)"

--- a/scripts/helper/codespaces-auth-add.sh
+++ b/scripts/helper/codespaces-auth-add.sh
@@ -224,7 +224,9 @@ normalise(){
   line=$(trim_whitespace "$line")
   
   # Parse first token
+  set -f
   set -- $line
+  set +f
   first="$1"
   
   case "$first" in
@@ -296,7 +298,9 @@ build_raw_list(){
       [ -z "$trimmed" ] && continue
       
       # Parse first token
+      set -f
       set -- $trimmed
+      set +f
       local first="$1"
       
       case "$first" in


### PR DESCRIPTION
This PR addresses two security robustness issues in the shell scripts:

1. **Unintentional Glob Expansion:** In `scripts/helper/codespaces-auth-add.sh`, the script used `set -- $line` to parse repositories from `repos.list`. Without `set -f`, an entry like `*` would be expanded by the shell into a list of files in the current directory. I've added `set -f` before these operations to disable globbing.
2. **Git Argument Injection:** Several Git commands (`ls-remote`, `fetch`) were missing the `--` separator before user-provided arguments like branch names. This could allow argument injection if a branch name started with a hyphen. I've added the `--` separator to the identified locations.

Verification:
- Created test cases to confirm that `*` in `repos.list` no longer expands to filenames.
- Confirmed that Git commands are protected against hyphenated branch names (using existing `test-git-hardening.sh`).
- Ran the full test suite to ensure no regressions.


---
*PR created automatically by Jules for task [6539621846562196588](https://jules.google.com/task/6539621846562196588) started by @MiguelRodo*