### PR TITLE
🛡️ Sentinel: Harden add-branch.sh against argument injection

### DIFF
--- a/scripts/add-branch.sh
+++ b/scripts/add-branch.sh
@@ -12,6 +12,13 @@
 
 set -Eeo pipefail
 
+# Never prompt for credentials (prevents stdin reads that can kill the loop)
+export GIT_TERMINAL_PROMPT=0
+export GIT_ASKPASS=/bin/false
+: "${GIT_SSH_COMMAND:=ssh -oBatchMode=yes}"
+
+git() { command git "$@" </dev/null; }
+
 # --- Paths ---
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -88,7 +95,7 @@ if [ -z "$BRANCH_NAME" ]; then
 fi
 
 # --- Validate we're in a git repo ---
-cd "$PROJECT_ROOT"
+cd -- "$PROJECT_ROOT"
 if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   echo "Error: not inside a Git working tree" >&2
   exit 1
@@ -119,9 +126,9 @@ else
   DEST="$PARENT_DIR/${REPO_NAME}-${SAFE_BRANCH_NAME}"
 fi
 
-echo "Creating worktree: $DEST"
-echo "  Branch: $BRANCH_NAME"
-echo "  Base repo: $PROJECT_ROOT"
+printf 'Creating worktree: %s\n' "$DEST"
+printf '  Branch: %s\n' "$BRANCH_NAME"
+printf '  Base repo: %s\n' "$PROJECT_ROOT"
 
 # --- Check if destination already exists ---
 if [ -e "$DEST" ]; then
@@ -139,24 +146,24 @@ fi
 git fetch origin >/dev/null 2>&1 || true
 
 if git ls-remote --exit-code --heads origin "$BRANCH_NAME" >/dev/null 2>&1; then
-  echo "Branch exists on origin, creating tracking worktree..."
+  printf 'Branch exists on origin, creating tracking worktree...\n'
   # Ensure we have the remote tracking branch
   git fetch origin "refs/heads/$BRANCH_NAME:refs/remotes/origin/$BRANCH_NAME" 2>/dev/null || true
   git worktree add -b "$BRANCH_NAME" -- "$DEST" "origin/$BRANCH_NAME" || \
     git worktree add -- "$DEST" "$BRANCH_NAME"
 else
-  echo "Creating new branch from current HEAD..."
+  printf 'Creating new branch from current HEAD...\n'
   git worktree add -b "$BRANCH_NAME" -- "$DEST"
   
   # Push to origin with tracking
-  echo "Pushing branch to origin..."
+  printf 'Pushing branch to origin...\n'
   git -C "$DEST" push -u origin -- "$BRANCH_NAME"
 fi
 
 # --- Clean the worktree ---
-echo "Cleaning worktree to minimal infrastructure..."
+printf 'Cleaning worktree to minimal infrastructure...\n'
 
-cd "$DEST"
+cd -- "$DEST"
 
 # Keep only .git, .gitignore, and .devcontainer
 KEEP_FILES=(
@@ -187,8 +194,8 @@ for item in *; do
   done
   
   if [ "$should_keep" = false ]; then
-    echo "  Removing: $item"
-    rm -rf "$item"
+    printf '  Removing: %s\n' "$item"
+    rm -rf -- "$item"
   fi
 done
 
@@ -197,7 +204,7 @@ for item in .[!.]*; do
   [ ! -e "$item" ] && continue
   case "$item" in
     .git|.gitignore|.devcontainer) continue ;;
-    *) echo "  Removing: $item"; rm -rf "$item" ;;
+    *) printf '  Removing: %s\n' "$item"; rm -rf -- "$item" ;;
   esac
 done
 
@@ -246,20 +253,20 @@ git commit -m "Initialize ${BRANCH_NAME} branch with minimal infrastructure" || 
 git push origin -- "$BRANCH_NAME" || true
 
 # --- Update repos.list ---
-cd "$PROJECT_ROOT"
-echo "Adding branch to repos.list..."
+cd -- "$PROJECT_ROOT"
+printf 'Adding branch to repos.list...\n'
 
 # Check if @branch line already exists
 if grep -q "^@${BRANCH_NAME}" repos.list 2>/dev/null; then
-  echo "  Branch already in repos.list"
+  printf '  Branch already in repos.list\n'
 else
   # Add after the current repo (first line or after any existing @branch lines from current repo)
   if [ -n "$TARGET_DIR" ]; then
-    echo "@${BRANCH_NAME} ${TARGET_DIR}" >> repos.list
+    printf '@%s %s\n' "$BRANCH_NAME" "$TARGET_DIR" >> repos.list
   else
-    echo "@${BRANCH_NAME}" >> repos.list
+    printf '@%s\n' "$BRANCH_NAME" >> repos.list
   fi
-  echo "  ✓ Added @${BRANCH_NAME} to repos.list"
+  printf '  ✓ Added @%s to repos.list\n' "$BRANCH_NAME"
 fi
 
 # --- Update workspace ---

--- a/scripts/add-branch.sh
+++ b/scripts/add-branch.sh
@@ -145,7 +145,7 @@ fi
 # Check if branch exists on origin
 git fetch origin >/dev/null 2>&1 || true
 
-if git ls-remote --exit-code --heads origin "$BRANCH_NAME" >/dev/null 2>&1; then
+if git ls-remote --exit-code --heads origin -- "$BRANCH_NAME" >/dev/null 2>&1; then
   printf 'Branch exists on origin, creating tracking worktree...\n'
   # Ensure we have the remote tracking branch
   git fetch origin "refs/heads/$BRANCH_NAME:refs/remotes/origin/$BRANCH_NAME" 2>/dev/null || true
@@ -220,7 +220,7 @@ if [ -f ".devcontainer/prebuild/devcontainer.json" ]; then
   # Remove the repositories section if it exists (using multiple approaches for portability)
   if command -v jq >/dev/null 2>&1; then
     # Use jq if available
-    echo "$PREBUILD_CONTENT" | jq 'del(.customizations.codespaces.repositories)' > .devcontainer/devcontainer.json
+    printf '%s\n' "$PREBUILD_CONTENT" | jq 'del(.customizations.codespaces.repositories)' > .devcontainer/devcontainer.json
   elif command -v python3 >/dev/null 2>&1; then
     # Use Python if available
     python3 -c "
@@ -238,7 +238,7 @@ print(json.dumps(data, indent=2))
   fi
   
   # Remove prebuild directory
-  rm -rf .devcontainer/prebuild
+  rm -rf -- .devcontainer/prebuild
   echo "  ✓ Devcontainer configured"
 elif [ -f ".devcontainer/devcontainer.json" ]; then
   echo "  Devcontainer already exists, keeping as-is"

--- a/scripts/run-pipeline.sh
+++ b/scripts/run-pipeline.sh
@@ -260,10 +260,10 @@ run_in_repo() {
         record_success "$repo_name" "$script_name"
       else
         $VERBOSE && echo "  chmod +x \"$target\""
-        chmod +x "$target"
+        chmod +x -- "$target"
         $VERBOSE && echo "  cd \"$full_path\" && ./$script_name"
         local rc=0
-        ( cd "$full_path" && "./$script_name" ) || rc=$?
+        ( cd -- "$full_path" && "./$script_name" ) || rc=$?
         if [ $rc -eq 0 ]; then
           record_success "$repo_name" "$script_name"
         else
@@ -354,7 +354,7 @@ main() {
       }
 
       local full_path
-      full_path="$(cd "$PROJECT_ROOT/.." && pwd)/$dir_name"
+      full_path="$(cd -- "$PROJECT_ROOT/.." && pwd)/$dir_name"
       run_in_repo "$full_path" "$dir_name" "$script_name"
     done < "$REPOS_FILE"
 

--- a/scripts/update-scripts.sh
+++ b/scripts/update-scripts.sh
@@ -196,7 +196,7 @@ copy_scripts() {
     elif [ -f "$item" ]; then
       # Copy file and preserve permissions
       cp "$item" "$dst_dir/$item_name"
-      chmod +x "$dst_dir/$item_name"
+      chmod +x -- "$dst_dir/$item_name"
       echo "  ✓ Updated $rel_item"
     fi
   done


### PR DESCRIPTION
This PR hardens `scripts/add-branch.sh` against argument injection and insecure output handling. 

Key improvements:
- Terminated option parsing with `--` before passing variable arguments to `rm`, `cd`, and `git` commands.
- Replaced `echo` with `printf` for all dynamic output and file appends to prevent strings starting with hyphens from being interpreted as command flags.
- Introduced a `git()` wrapper function and set standard environment variables to ensure non-interactive execution in automated environments.
- Sanitized `repos.list` updates to safely handle arbitrary branch names.

These changes follow the security patterns established in the repository to prevent common shell script vulnerabilities.

---
*PR created automatically by Jules for task [11097331770136521905](https://jules.google.com/task/11097331770136521905) started by @MiguelRodo*