### PR TITLE
🛡️ Sentinel: [improvement] Harden shell scripts with nounset and option separators

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -74,3 +74,8 @@
 **Vulnerability:** The `-d/--devcontainer` argument in `codespaces-auth-add.sh` allowed arbitrary paths (absolute or `..`), enabling overwriting of system files. Additionally, a regex intended to strip JSONC comments (`//`) incorrectly matched `//` inside URLs (e.g. `https://`), corrupting data.
 **Learning:** Argument parsing for file paths must always be hardened with validation logic, even in internal helpers. Heuristic-based parsing (like regex for JSONC) is dangerous and must account for common edge cases like protocol prefixes in URLs.
 **Prevention:** Always validate user-provided paths for `-d` arguments using a strict check against `/*|*..*`. Use negative lookbehind in regex (e.g. `(?<!:)\/\/`) to avoid matching protocol separators when stripping comments.
+
+## 2025-06-10 - [Medium] Pervasive Missing Nounset and Option Terminators in Shell Tooling
+**Vulnerability:** Multiple secondary and helper scripts (e.g., `run-pipeline.sh`, `update-scripts.sh`) were missing `set -u` (nounset) and the `--` option terminator for common commands like `basename` and `git add`.
+**Learning:** While core scripts were hardened, utility scripts often trailed behind in security standards. `basename` is particularly susceptible to argument injection if a path component starts with a hyphen.
+**Prevention:** Enforce `set -u` across all scripts to catch uninitialized variables. Consistently use the `--` separator for *all* commands that accept variable-based positional arguments, including standard utilities like `basename`, `dirname`, and `git add`.

--- a/scripts/add-branch.sh
+++ b/scripts/add-branch.sh
@@ -130,7 +130,7 @@ sanitize_branch_name() {
 }
 
 # --- Determine destination ---
-REPO_NAME="$(basename "$PROJECT_ROOT")"
+REPO_NAME="$(basename -- "$PROJECT_ROOT")"
 PARENT_DIR="$(dirname "$PROJECT_ROOT")"
 
 if [ -n "$TARGET_DIR" ]; then

--- a/scripts/helper/clone-repos.sh
+++ b/scripts/helper/clone-repos.sh
@@ -25,7 +25,7 @@
 #       - Otherwise the first single-branch clone becomes the base.
 #     No side “-base” directories are created.
 
-set -Eeo pipefail
+set -Eeuo pipefail
 # Never prompt for credentials (prevents stdin reads that can kill the loop)
 export GIT_TERMINAL_PROMPT=0
 export GIT_ASKPASS=/bin/false
@@ -642,15 +642,15 @@ clone_one_repo() {
   case "$repo_url_no_ref" in
     file://*)
       repo_url="$repo_url_no_ref"
-      repo_dir=$(basename "${repo_url_no_ref%.git}")
+      repo_dir=$(basename -- "${repo_url_no_ref%.git}")
       ;;
     /*)
       repo_url="$repo_url_no_ref"
-      repo_dir=$(basename "${repo_url_no_ref%.git}")
+      repo_dir=$(basename -- "${repo_url_no_ref%.git}")
       ;;
     https://*)
       repo_url="$repo_url_no_ref"
-      repo_dir=$(basename "${repo_url_no_ref%.git}")
+      repo_dir=$(basename -- "${repo_url_no_ref%.git}")
       ;;
     */*)
       # Only convert to GitHub URL if it looks like owner/repo (not a path)
@@ -660,7 +660,7 @@ clone_one_repo() {
       else
         # Looks like a path with multiple slashes
         repo_url="$repo_url_no_ref"
-        repo_dir=$(basename "${repo_url_no_ref%.git}")
+        repo_dir=$(basename -- "${repo_url_no_ref%.git}")
       fi
       ;;
     *)
@@ -825,7 +825,7 @@ create_worktree_for_branch() {
     return 2
   fi
 
-  local repo_base; repo_base="$(basename "$base")"
+  local repo_base; repo_base="$(basename -- "$base")"
   local dest
   if [ -n "$target_dir" ]; then
     dest="$parent_dir/$target_dir"
@@ -1204,11 +1204,11 @@ main() {
           if [ "$is_at_branch" -eq 1 ] && [ "$is_branch_clone" -eq 1 ] && [ -z "$target_dir" ]; then
             local fallback_local_name
             if [ "$fallback_repo_https" = "$current_repo_https" ]; then
-              fallback_local_name="$(basename "$start_dir")"
+              fallback_local_name="$(basename -- "$start_dir")"
             else
               local idx; idx="$(remote_index "$fallback_repo_https")"
               if [ "$idx" -ge 0 ] && [ -n "${REMOTE_LOCAL_PATH[$idx]}" ]; then
-                fallback_local_name="$(basename "${REMOTE_LOCAL_PATH[$idx]}")"
+                fallback_local_name="$(basename -- "${REMOTE_LOCAL_PATH[$idx]}")"
               else
                 fallback_local_name="$(plan_base_name "$fallback_repo_https")"
               fi

--- a/scripts/run-pipeline.sh
+++ b/scripts/run-pipeline.sh
@@ -9,7 +9,7 @@
 #
 # Path logic follows clone-repos.sh conventions
 
-set -Eeo pipefail
+set -Eeuo pipefail
 
 # --- Paths ---
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -396,7 +396,7 @@ main() {
       esac
       local full_path="$PROJECT_ROOT/$folder_path"
       local repo_name
-      repo_name="$(basename "$full_path")"
+      repo_name="$(basename -- "$full_path")"
       run_in_repo "$full_path" "$repo_name" "$RUN_SCRIPT"
     done < <(jq -r '.folders[].path' "$workspace_file")
 

--- a/scripts/update-branches.sh
+++ b/scripts/update-branches.sh
@@ -154,7 +154,7 @@ with open(os.environ['TMP_DEST'], 'w') as f:
     echo "    ℹ️  No changes to commit"
     SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
   else
-    git add ".devcontainer/devcontainer.json"
+    git add -- ".devcontainer/devcontainer.json"
     git commit -m "Update devcontainer from latest prebuild"
     
     # Get current branch

--- a/scripts/update-scripts.sh
+++ b/scripts/update-scripts.sh
@@ -4,7 +4,7 @@
 #
 # This script pulls the latest scripts from the CompTemplate repository
 
-set -Eeo pipefail
+set -Eeuo pipefail
 
 # --- Configuration ---
 UPSTREAM_REPO="https://github.com/MiguelRodo/CompTemplate.git"
@@ -58,7 +58,7 @@ FORCE=false
 while [ "$#" -gt 0 ]; do
   case "$1" in
     -b|--branch)
-      shift; UPSTREAM_BRANCH="$1"; shift ;;
+      shift; [ $# -gt 0 ] || usage; UPSTREAM_BRANCH="$1"; shift ;;
     -n|--dry-run)
       DRY_RUN=true; shift ;;
     -f|--force)
@@ -70,6 +70,12 @@ while [ "$#" -gt 0 ]; do
       usage; exit 1 ;;
   esac
 done
+
+# Validate upstream branch name
+if ! git check-ref-format --allow-onelevel "$UPSTREAM_BRANCH" || [[ "$UPSTREAM_BRANCH" == -* ]]; then
+  echo "Error: '$UPSTREAM_BRANCH' is not a valid Git branch name." >&2
+  exit 1
+fi
 
 # --- Validate environment ---
 cd "$PROJECT_ROOT"
@@ -124,7 +130,7 @@ list_scripts() {
   for item in "$src_dir"/*; do
     [ ! -e "$item" ] && continue
     
-    local item_name="$(basename "$item")"
+    local item_name="$(basename -- "$item")"
     local rel_item="${rel_path:+$rel_path/}$item_name"
     
     if [ -d "$item" ]; then
@@ -185,7 +191,7 @@ copy_scripts() {
   for item in "$src_dir"/*; do
     [ ! -e "$item" ] && continue
     
-    local item_name="$(basename "$item")"
+    local item_name="$(basename -- "$item")"
     local rel_item="${rel_path:+$rel_path/}$item_name"
     
     if [ -d "$item" ]; then
@@ -208,7 +214,7 @@ copy_scripts "$UPSTREAM_SCRIPTS" "$TARGET_DIR" ""
 echo ""
 echo "Committing changes..."
 
-git add "$TARGET_DIR"
+git add -- "$TARGET_DIR"
 
 if git diff --staged --quiet; then
   echo "No changes to commit (files may be identical)."


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Potential for argument injection in `basename` and `git add` commands, and lack of strict variable validation (`nounset`).
🎯 Impact: A maliciously named file (e.g., starting with a hyphen) could be interpreted as a flag by system utilities, potentially leading to command injection or unexpected behavior.
🔧 Fix: Consistently applied the `--` separator to terminate option parsing before passing positional arguments. Enabled `set -u` for stricter variable checking. Added `git check-ref-format` for branch name validation.
✅ Verification: Ran the full test suite and specific security hardening tests (`test-security-hardening.sh`, `test-git-hardening.sh`, `test-branch-hardening.sh`). All tests passed, and manual verification confirmed that malicious branch names are correctly rejected.

---
*PR created automatically by Jules for task [7720814238754402166](https://jules.google.com/task/7720814238754402166) started by @MiguelRodo*