### PR TITLE
🛡️ Sentinel: [security improvement] Harden Git and grep commands against argument injection

### DIFF
--- a/scripts/helper/clone-repos.sh
+++ b/scripts/helper/clone-repos.sh
@@ -479,16 +479,18 @@ get_current_repo_remote_https() {
   }
 
   local url="" first=""
-  if git remote | grep -qx 'origin'; then
-    if ! url="$(git remote get-url --push origin 2>/dev/null)"; then
-      url="$(git remote get-url origin 2>/dev/null || true)"
+  # Use grep -e and git remote get-url -- to prevent argument injection
+  # from remote names starting with a hyphen
+  if git remote | grep -qx -e 'origin'; then
+    if ! url="$(git remote get-url --push -- origin 2>/dev/null)"; then
+      url="$(git remote get-url -- origin 2>/dev/null || true)"
     fi
   fi
 
   if [ -z "$url" ]; then
     if first="$(git remote 2>/dev/null | head -n1)"; then
-      if ! url="$(git remote get-url --push "$first" 2>/dev/null)"; then
-        url="$(git remote get-url "$first" 2>/dev/null || true)"
+      if ! url="$(git remote get-url --push -- "$first" 2>/dev/null)"; then
+        url="$(git remote get-url -- "$first" 2>/dev/null || true)"
       fi
     fi
   fi
@@ -527,7 +529,8 @@ ensure_wildcard_fetch_refspec() {
   local wildcard_refspec="+refs/heads/*:refs/remotes/origin/*"
   
   # Check if wildcard refspec already exists
-  if git -C "$base" config --get-all remote.origin.fetch | grep -qF "$wildcard_refspec"; then
+  # Use grep -e to handle patterns starting with a hyphen literally
+  if git -C "$base" config --get-all remote.origin.fetch | grep -qF -e "$wildcard_refspec"; then
     return 0
   fi
   

--- a/scripts/helper/codespaces-auth-add.sh
+++ b/scripts/helper/codespaces-auth-add.sh
@@ -197,17 +197,19 @@ get_current_repo_remote_https() {
   local url="" first="" remotes
   remotes="$(git remote 2>/dev/null || true)"
   
-  if echo "$remotes" | grep -qx 'origin'; then
-    if ! url="$(git remote get-url --push origin 2>/dev/null)"; then
-      url="$(git remote get-url origin 2>/dev/null || true)"
+  # Use printf, grep -e, and git remote get-url -- to prevent argument injection
+  # and misinterpretation of variables starting with a hyphen
+  if printf '%s\n' "$remotes" | grep -qx -e 'origin'; then
+    if ! url="$(git remote get-url --push -- origin 2>/dev/null)"; then
+      url="$(git remote get-url -- origin 2>/dev/null || true)"
     fi
   fi
 
   if [ -z "$url" ] && [ -n "$remotes" ]; then
-    first="$(echo "$remotes" | head -n1)"
+    first="$(printf '%s\n' "$remotes" | head -n1)"
     if [ -n "$first" ]; then
-      if ! url="$(git remote get-url --push "$first" 2>/dev/null)"; then
-        url="$(git remote get-url "$first" 2>/dev/null || true)"
+      if ! url="$(git remote get-url --push -- "$first" 2>/dev/null)"; then
+        url="$(git remote get-url -- "$first" 2>/dev/null || true)"
       fi
     fi
   fi


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Potential argument injection in `git remote get-url` and `grep` commands, and unsafe variable output with `echo`.
🎯 Impact: If a repository has a remote named with a leading hyphen (e.g., `-h`), it could trigger unintended command options, potentially causing script failures or unexpected behavior. `echo` could also misinterpret variable values starting with hyphens.
🔧 Fix:
- Added `--` option terminator to `git remote get-url` calls when using variable-based remote names.
- Replaced `echo "$variable"` with `printf '%s\n' "$variable"` for safe output of remote names.
- Added `-e` flag to `grep` calls to ensure patterns starting with hyphens are treated as literal strings.
- Added inline documentation explaining these defensive patterns.
✅ Verification: Ran `tests/test-security-hardening.sh`, `tests/test-git-hardening.sh`, and `tests/test-branch-hardening.sh`. Also ran a custom reproduction script that specifically verified handling of a remote named `-h`.

---
*PR created automatically by Jules for task [8427678858770992748](https://jules.google.com/task/8427678858770992748) started by @MiguelRodo*