### PR TITLE
🛡️ Sentinel: [improvement] Harden scripts for non-interactive Git use

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -79,3 +79,8 @@
 **Vulnerability:** Multiple secondary and helper scripts (e.g., `run-pipeline.sh`, `update-scripts.sh`) were missing `set -u` (nounset) and the `--` option terminator for common commands like `basename` and `git add`.
 **Learning:** While core scripts were hardened, utility scripts often trailed behind in security standards. `basename` is particularly susceptible to argument injection if a path component starts with a hyphen.
 **Prevention:** Enforce `set -u` across all scripts to catch uninitialized variables. Consistently use the `--` separator for *all* commands that accept variable-based positional arguments, including standard utilities like `basename`, `dirname`, and `git add`.
+
+## 2025-06-11 - [Improvement] Non-Interactive Git Hardening and Robust JSON Processing
+**Pattern:** Core scripts lacked explicit hardening for non-interactive Git use, potentially leading to hangs in automated environments (like CI/CD) when credentials were requested. Additionally, large JSON processing used shell variable expansion, risking "Argument list too long" errors.
+**Learning:** Automated scripts must explicitly disable terminal prompts for Git and SSH to ensure they fail fast rather than hanging. Relying on shell variable expansion for large configuration files is fragile.
+**Prevention:** Export `GIT_TERMINAL_PROMPT=0` and `GIT_ASKPASS=/bin/false` in all scripts using Git. Use a `git` wrapper function that redirects `/dev/null` to stdin. For JSON processing, have tools read directly from file paths instead of using intermediate shell variables.

--- a/scripts/add-branch.sh
+++ b/scripts/add-branch.sh
@@ -12,6 +12,13 @@
 
 set -Eeuo pipefail
 
+# Never prompt for credentials (prevents stdin reads that can kill the loop)
+export GIT_TERMINAL_PROMPT=0
+export GIT_ASKPASS=/bin/false
+export GIT_SSH_COMMAND="${GIT_SSH_COMMAND:-ssh -oBatchMode=yes}"
+
+git() { command git "$@" </dev/null; }
+
 # --- Paths ---
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -235,27 +242,31 @@ echo "Setting up devcontainer..."
 if [ -f ".devcontainer/prebuild/devcontainer.json" ]; then
   echo "  Moving prebuild devcontainer to main location..."
   
-  # Read the prebuild devcontainer
-  PREBUILD_CONTENT="$(cat -- .devcontainer/prebuild/devcontainer.json)"
+  PREBUILD_FILE=".devcontainer/prebuild/devcontainer.json"
+  DEST_FILE=".devcontainer/devcontainer.json"
   
   # Remove the repositories section if it exists (using multiple approaches for portability)
   if command -v jq >/dev/null 2>&1; then
-    # Use jq if available
-    printf '%s\n' "$PREBUILD_CONTENT" | jq 'del(.customizations.codespaces.repositories)' > .devcontainer/devcontainer.json
+    # Use jq if available (reads directly from file)
+    jq 'del(.customizations.codespaces.repositories)' -- "$PREBUILD_FILE" > "$DEST_FILE"
   elif command -v python3 >/dev/null 2>&1; then
-    # Use Python if available
+    # Use Python if available (reads directly from file via env var)
+    export PREBUILD_FILE DEST_FILE
     python3 -c "
-import json, sys
-data = json.loads(sys.stdin.read())
+import json, sys, os
+with open(os.environ['PREBUILD_FILE']) as f:
+    data = json.load(f)
 if 'customizations' in data and 'codespaces' in data['customizations']:
     if 'repositories' in data['customizations']['codespaces']:
         del data['customizations']['codespaces']['repositories']
-print(json.dumps(data, indent=2))
-" <<< "$PREBUILD_CONTENT" > .devcontainer/devcontainer.json
+with open(os.environ['DEST_FILE'], 'w') as f:
+    json.dump(data, f, indent=2)
+    f.write('\n')
+"
   else
     # Fallback: just copy it (will have repositories section but still works)
     echo "  Warning: jq and python3 not found; copying devcontainer as-is"
-    cp -- .devcontainer/prebuild/devcontainer.json .devcontainer/devcontainer.json
+    cp -- "$PREBUILD_FILE" "$DEST_FILE"
   fi
   
   # Remove prebuild directory

--- a/scripts/helper/codespaces-auth-add.sh
+++ b/scripts/helper/codespaces-auth-add.sh
@@ -8,6 +8,13 @@ set -o errexit   # same as -e
 set -o nounset   # same as -u
 set -o pipefail
 
+# Never prompt for credentials (prevents stdin reads that can kill the loop)
+export GIT_TERMINAL_PROMPT=0
+export GIT_ASKPASS=/bin/false
+export GIT_SSH_COMMAND="${GIT_SSH_COMMAND:-ssh -oBatchMode=yes}"
+
+git() { command git "$@" </dev/null; }
+
 # ——— Defaults ———————————————————————————————————————————————
 # Validate devcontainer path to prevent path traversal
 validate_devcontainer_path() {

--- a/scripts/helper/create-repos.sh
+++ b/scripts/helper/create-repos.sh
@@ -6,6 +6,13 @@ set -o errexit   # same as -e
 set -o nounset   # same as -u
 set -o pipefail
 
+# Never prompt for credentials (prevents stdin reads that can kill the loop)
+export GIT_TERMINAL_PROMPT=0
+export GIT_ASKPASS=/bin/false
+export GIT_SSH_COMMAND="${GIT_SSH_COMMAND:-ssh -oBatchMode=yes}"
+
+git() { command git "$@" </dev/null; }
+
 # — Prerequisites —
 for cmd in curl git jq mktemp; do
   if ! command -v "$cmd" >/dev/null 2>&1; then

--- a/scripts/update-branches.sh
+++ b/scripts/update-branches.sh
@@ -7,6 +7,13 @@
 
 set -Eeuo pipefail
 
+# Never prompt for credentials (prevents stdin reads that can kill the loop)
+export GIT_TERMINAL_PROMPT=0
+export GIT_ASKPASS=/bin/false
+export GIT_SSH_COMMAND="${GIT_SSH_COMMAND:-ssh -oBatchMode=yes}"
+
+git() { command git "$@" </dev/null; }
+
 # --- Paths ---
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"

--- a/scripts/update-scripts.sh
+++ b/scripts/update-scripts.sh
@@ -6,6 +6,13 @@
 
 set -Eeuo pipefail
 
+# Never prompt for credentials (prevents stdin reads that can kill the loop)
+export GIT_TERMINAL_PROMPT=0
+export GIT_ASKPASS=/bin/false
+export GIT_SSH_COMMAND="${GIT_SSH_COMMAND:-ssh -oBatchMode=yes}"
+
+git() { command git "$@" </dev/null; }
+
 # --- Configuration ---
 UPSTREAM_REPO="https://github.com/MiguelRodo/CompTemplate.git"
 UPSTREAM_BRANCH="${UPSTREAM_BRANCH:-main}"


### PR DESCRIPTION
### 🛡️ Sentinel: [improvement] Harden scripts for non-interactive Git use

#### 🚨 Severity: MEDIUM (Operational Security)

#### 💡 Vulnerability
Core and utility scripts lacked explicit hardening for non-interactive Git operations. This could cause scripts to hang indefinitely in automated environments (like CI/CD or background tasks) if Git or SSH prompted for credentials or confirmation. Additionally, `add-branch.sh` used shell variable expansion for large `devcontainer.json` files, which is fragile and can lead to "Argument list too long" errors.

#### 🎯 Impact
- Automated pipelines could hang or fail obscurely due to interactive prompts.
- Fragile JSON processing in `add-branch.sh` could fail for large configurations.

#### 🔧 Fix
1.  **Non-Interactive Git Hardening:** Added a standard header block to `add-branch.sh`, `update-branches.sh`, `update-scripts.sh`, `create-repos.sh`, and `codespaces-auth-add.sh` that:
    *   Exports `GIT_TERMINAL_PROMPT=0` and `GIT_ASKPASS=/bin/false`.
    *   Exports `GIT_SSH_COMMAND` with `BatchMode=yes`.
    *   Defines a `git()` wrapper function that redirects `/dev/null` to stdin.
2.  **Robust JSON Processing:** Refactored `add-branch.sh` to have `jq` and `python3` read directly from the `.devcontainer/prebuild/devcontainer.json` file instead of passing its content through a shell variable.

#### ✅ Verification
- Ran `tests/test-git-hardening.sh` to confirm `git` commands correctly handle hyphenated arguments (defense-in-depth).
- Ran `tests/test-add-branch-security.sh` to verify `add-branch.sh` functionality.
- Ran the full integration suite (`tests/test-setup-repos-local.sh`, `tests/test-security-hardening.sh`, etc.) to ensure no regressions.
- Verified all 5 modified scripts with `read_file` to ensure correct implementation.

---
*PR created automatically by Jules for task [6463960129900271775](https://jules.google.com/task/6463960129900271775) started by @MiguelRodo*