### PR TITLE
🛡️ Sentinel: [security improvement] Sanitize credentials and improve mktemp portability

### DIFF
--- a/scripts/helper/clone-repos.sh
+++ b/scripts/helper/clone-repos.sh
@@ -964,7 +964,7 @@ parse_args() {
         else
           # Auto-generate debug file securely
           TEMP_DIR=$(get_temp_dir)
-          DEBUG_FILE_ARG=$(mktemp -- "${TEMP_DIR}/repos-clone-debug-XXXXXX")
+          DEBUG_FILE_ARG=$(mktemp "${TEMP_DIR}/repos-clone-debug-XXXXXX")
         fi
         ;;
       -h|--help) usage; exit 0 ;;

--- a/scripts/helper/codespaces-auth-add.sh
+++ b/scripts/helper/codespaces-auth-add.sh
@@ -479,7 +479,7 @@ update_with_jq(){
       { customizations:{ codespaces:{ repositories:$repos } } }
     ' >"$file"
   else
-    tmp="$(mktemp -- "$(get_temp_dir)/repos-auth-XXXXXX")"
+    tmp="$(mktemp "$(get_temp_dir)/repos-auth-XXXXXX")"
     jq --argjson repos "$repos_obj" '
       .customizations.codespaces.repositories
         |= ( (. // {}) + $repos )
@@ -619,7 +619,7 @@ update_devfile(){
         update_with_python "$devfile" "$tool"
       else
         # Safely write via a temporary file, then move into place
-        tmp="$(mktemp -- "$(get_temp_dir)/repos-auth-XXXXXX")"
+        tmp="$(mktemp "$(get_temp_dir)/repos-auth-XXXXXX")"
         update_with_python "$devfile" "$tool" > "$tmp"
         mv -- "$tmp" "$devfile"
         echo "Updated '$devfile' with $tool."

--- a/scripts/helper/create-repos.sh
+++ b/scripts/helper/create-repos.sh
@@ -94,7 +94,7 @@ while [ $# -gt 0 ]; do
       else
         # Auto-generate debug file securely
         TEMP_DIR=$(get_temp_dir)
-        DEBUG_FILE=$(mktemp -- "${TEMP_DIR}/repos-create-debug-XXXXXX")
+        DEBUG_FILE=$(mktemp "${TEMP_DIR}/repos-create-debug-XXXXXX")
       fi
       ;;
     -h|--help)    usage 0 ;;
@@ -121,6 +121,11 @@ debug "Private flag: $PRIVATE_FLAG"
 # Returns 0 if credentials are available, 1 if not
 get_credentials() {
   debug "Attempting to get GitHub credentials..."
+
+  # Sanitize existing credentials from environment
+  [ -n "${GH_USER-}" ] && GH_USER=$(printf '%s\n' "$GH_USER" | tr -d '\r\n')
+  [ -n "${GH_TOKEN-}" ] && GH_TOKEN=$(printf '%s\n' "$GH_TOKEN" | tr -d '\r\n')
+
   if [ -z "${GH_TOKEN-}" ] || [ -z "${GH_USER-}" ]; then
     debug "GH_TOKEN or GH_USER not set, trying git credential fill..."
     # Try to get credentials, but don't fail if unavailable
@@ -133,10 +138,10 @@ get_credentials() {
       return 1
     fi
     [ -z "${GH_USER-}" ] && \
-      GH_USER=$(printf '%s\n' "$creds" | tr -d '\r' | awk -F= '/^username=/ {print $2}')
+      GH_USER=$(printf '%s\n' "$creds" | tr -d '\r' | awk -F= '/^username=/ {print $2}' | tr -d '\r\n')
     [ -z "${GH_TOKEN-}" ] && \
-      GH_TOKEN=$(printf '%s\n' "$creds" | tr -d '\r' | awk -F= '/^password=/ {print $2}')
-    
+      GH_TOKEN=$(printf '%s\n' "$creds" | tr -d '\r' | awk -F= '/^password=/ {print $2}' | tr -d '\r\n')
+
     debug "Retrieved GH_USER: ${GH_USER:+<present>}"
     debug "Retrieved GH_TOKEN: ${GH_TOKEN:+<present>}"
     

--- a/scripts/helper/vscode-workspace-add.sh
+++ b/scripts/helper/vscode-workspace-add.sh
@@ -112,7 +112,7 @@ update_with_jq() {
       > "$workspace_file"
   else
     # merge into existing file: set .folders = $folders
-    tmp="$(mktemp -- "$(get_temp_dir)/repos-workspace-XXXXXX")"
+    tmp="$(mktemp "$(get_temp_dir)/repos-workspace-XXXXXX")"
     jq --argjson folders "$folders_json" \
        '.folders = $folders' \
        -- "$workspace_file" > "$tmp" \
@@ -655,7 +655,7 @@ main() {
         else
           # Auto-generate debug file securely
           TEMP_DIR=$(get_temp_dir)
-          DEBUG_FILE=$(mktemp -- "${TEMP_DIR}/repos-workspace-debug-XXXXXX")
+          DEBUG_FILE=$(mktemp "${TEMP_DIR}/repos-workspace-debug-XXXXXX")
         fi
         ;;
       -h|--help)

--- a/scripts/setup-repos.sh
+++ b/scripts/setup-repos.sh
@@ -115,7 +115,7 @@ while [ $# -gt 0 ]; do
       else
         # Auto-generate debug file securely
         TEMP_DIR=$(get_temp_dir)
-        DEBUG_FILE=$(mktemp -- "${TEMP_DIR}/repos-debug-XXXXXX")
+        DEBUG_FILE=$(mktemp "${TEMP_DIR}/repos-debug-XXXXXX")
       fi
       ;;
     -h|--help)      usage 0 ;;

--- a/scripts/update-branches.sh
+++ b/scripts/update-branches.sh
@@ -131,7 +131,7 @@ while IFS= read -r line; do
   fi
   
   # Read and process the prebuild file securely
-  TMP_DEST=$(mktemp -- "$DEST_FILE.XXXXXX")
+  TMP_DEST=$(mktemp "$DEST_FILE.XXXXXX")
   if [ "$JSON_TOOL" = "jq" ]; then
     jq 'del(.customizations.codespaces.repositories)' -- "$PREBUILD_FILE" > "$TMP_DEST"
   else


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Potential HTTP header injection via unsanitized environment variables and portability issues with `mktemp`.
🎯 Impact: Malicious or accidental CRLF characters in `GH_TOKEN` or `GH_USER` could lead to corrupted API requests. Incompatible `mktemp` flags would cause script failures on macOS/BSD.
🔧 Fix: Added `tr -d '\r\n'` to sanitize credentials and removed `--` from `mktemp` calls. Corrected credential parsing logic to preserve multi-line format for `awk`.
✅ Verification: Successfully ran `tests/test-create-repos-security.sh`, `tests/test-auth-check.sh`, and `tests/test-credential-crlf.sh`.

---
*PR created automatically by Jules for task [5369347310546468819](https://jules.google.com/task/5369347310546468819) started by @MiguelRodo*