### PR TITLE
🛡️ Sentinel: [security improvement] Harden create-repos.sh API calls and fix Bash bug

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -99,3 +99,8 @@
 **Vulnerability:** `get_credentials` used `awk -F=` to parse `git credential fill` output, which truncated tokens containing equals signs. It also lacked CRLF sanitization for `GH_USER` and `GH_TOKEN` environment variables.
 **Learning:** Using a single character delimiter like `=` for parsing key-value pairs is fragile if the value itself can contain that delimiter. GitHub tokens frequently contain `=` characters. Lack of sanitization of user-provided environment variables in scripts that interact with web APIs can lead to header injection vulnerabilities.
 **Prevention:** Use `sed -n 's/^key=//p'` for robust extraction of values from key-value pairs. Always sanitize external inputs (including environment variables) with `tr -d '\r\n'` before using them in HTTP headers or security-sensitive contexts.
+
+## 2025-08-20 - [Improvement] Reusable URL Encoding Pattern for API Interactions
+**Vulnerability:** GitHub API components (owner, repo, branch) were interpolated directly into URL strings without encoding. While primary validation regexes restricted most characters, branch names (validated only by `git check-ref-format`) could contain characters like `/` or `#` that would break URL structure or lead to path manipulation.
+**Learning:** Even with input validation, parameters destined for URL paths must be explicitly encoded to ensure they are treated as literal data by the receiving API and to prevent misinterpretation of URL metacharacters.
+**Prevention:** Implement a reusable `urlencode` helper using `jq -rR '@uri'` (available in the project's environment) and apply it to all user-controlled or external data interpolated into URL strings.

--- a/scripts/helper/create-repos.sh
+++ b/scripts/helper/create-repos.sh
@@ -49,6 +49,11 @@ get_temp_dir() {
   fi
 }
 
+# URL encode a string using jq
+urlencode() {
+  printf '%s' "$1" | jq -rR '@uri'
+}
+
 # ── CONFIG & USAGE ─────────────────────────────────────────────────────────────
 if [ ! -f "repos.list" ] && [ -f "repos-to-clone.list" ]; then
   REPOS_FILE="repos-to-clone.list"
@@ -228,13 +233,18 @@ api_get_field() {
 
 create_branch() {
   local owner="$1"; local repo="$2"; local newbr="$3"
+  local e_owner e_repo e_defbr
+  e_owner=$(urlencode "$owner")
+  e_repo=$(urlencode "$repo")
+
   local defbr
-  defbr=$( api_get_field "$API_URL/repos/$owner/$repo" "default_branch" )
+  defbr=$( api_get_field "$API_URL/repos/$e_owner/$e_repo" "default_branch" )
+  e_defbr=$(urlencode "$defbr")
 
   local defsha
   defsha=$(
     curl -s -H "$AUTH_HDR" \
-      "$API_URL/repos/$owner/$repo/git/ref/heads/$defbr" \
+      "$API_URL/repos/$e_owner/$e_repo/git/ref/heads/$e_defbr" \
     | jq -r '.object.sha // .sha'
   )
 
@@ -244,7 +254,7 @@ create_branch() {
   curl -s -o /dev/null -w "%{http_code}" -X POST \
     -H "$AUTH_HDR" -H "Content-Type: application/json" \
     -d "$payload" \
-    "$API_URL/repos/$owner/$repo/git/refs"
+    "$API_URL/repos/$e_owner/$e_repo/git/refs"
 }
 
 # ── Get current repo info (for initial fallback) ───────────────────────────────
@@ -402,7 +412,7 @@ while IFS= read -r line || [ -n "$line" ]; do
       ref_status=$(
         curl -s -o /dev/null -w "%{http_code}" \
           -H "$AUTH_HDR" \
-          "$API_URL/repos/$fallback_owner/$fallback_repo/git/refs/heads/$branch"
+          "$API_URL/repos/$(urlencode "$fallback_owner")/$(urlencode "$fallback_repo")/git/refs/heads/$(urlencode "$branch")"
       )
       debug "Line $line_num: Branch check returned HTTP $ref_status"
       if [ "$ref_status" -eq 200 ]; then
@@ -518,14 +528,14 @@ while IFS= read -r line || [ -n "$line" ]; do
 
   # 1) Determine owner type (User vs Organization)
   debug "Line $line_num: Checking owner type for $owner"
-  owner_info=$(curl -s -H "$AUTH_HDR" "$API_URL/users/$owner")
+  owner_info=$(curl -s -H "$AUTH_HDR" "$API_URL/users/$(urlencode "$owner")")
   owner_type=$(printf '%s\n' "$owner_info" | jq -r '.type // empty')
   
   debug "Line $line_num: Owner type: $owner_type"
 
   case "$owner_type" in
     Organization)
-      create_url="$API_URL/orgs/$owner/repos"
+      create_url="$API_URL/orgs/$(urlencode "$owner")/repos"
       ;;
     User)
       create_url="$API_URL/user/repos"
@@ -540,7 +550,7 @@ while IFS= read -r line || [ -n "$line" ]; do
   status=$(
     curl -s -o /dev/null -w "%{http_code}" \
       -H "$AUTH_HDR" \
-      "$API_URL/repos/$owner/$repo"
+      "$API_URL/repos/$(urlencode "$owner")/$(urlencode "$repo")"
   )
   if [ "$status" -eq 200 ]; then
     printf "Exists: %s/%s\n" "$owner" "$repo"
@@ -548,7 +558,7 @@ while IFS= read -r line || [ -n "$line" ]; do
     # build payload (auto_init if we’ll push a branch later)
     # Determine if this repo should be private or public
     # Line-specific flag takes precedence over global flag
-    local this_repo_private
+    this_repo_private=""
     if [ -n "$line_is_public" ]; then
       # Line has explicit --public or --private flag
       if [ "$line_is_public" = "true" ]; then
@@ -595,7 +605,7 @@ while IFS= read -r line || [ -n "$line" ]; do
     ref_status=$(
       curl -s -o /dev/null -w "%{http_code}" \
         -H "$AUTH_HDR" \
-        "$API_URL/repos/$owner/$repo/git/refs/heads/$branch"
+        "$API_URL/repos/$(urlencode "$owner")/$(urlencode "$repo")/git/refs/heads/$(urlencode "$branch")"
     )
     if [ "$ref_status" -eq 200 ]; then
       printf "Branch exists: %s\n" "$branch"

--- a/tests/test-create-repos-enhancements.sh
+++ b/tests/test-create-repos-enhancements.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# tests/test-create-repos-enhancements.sh
+# Verifies URL encoding and fix for 'local' bug in create-repos.sh
+
+set -Eeuo pipefail
+
+# --- Setup ---
+TEST_DIR=$(mktemp -d)
+trap 'rm -rf -- "$TEST_DIR"' EXIT
+
+REPO_ROOT=$(pwd)
+CREATE_SCRIPT="$REPO_ROOT/scripts/helper/create-repos.sh"
+
+cd -- "$TEST_DIR"
+
+# Mock curl to log URLs and return dummy JSON or HTTP code
+cat > mock-curl <<'EOF'
+#!/usr/bin/env bash
+URL=""
+WANT_CODE=0
+for arg in "$@"; do
+    if [[ "$arg" == http* ]]; then URL="$arg"; fi
+    if [[ "$arg" == "%{http_code}" ]]; then WANT_CODE=1; fi
+done
+[ -n "$URL" ] && echo "$URL" >> curl_calls.log
+
+if [ "$WANT_CODE" -eq 1 ]; then
+    if [[ "$URL" == *"users/owner.name" ]]; then echo "200"; exit 0; fi
+    if [[ "$URL" == *"repos/owner.name/repo.name/git/refs/heads/branch%2Fwith%2Fslash" ]]; then echo "404"; exit 0; fi
+    if [[ "$URL" == *"repos/owner.name/repo.name" ]]; then echo "200"; exit 0; fi
+    if [[ "$URL" == *"user" ]]; then echo "200"; exit 0; fi
+    echo "404"
+    exit 0
+fi
+
+# Return dummy JSON based on the URL
+if [[ "$URL" == *"users/owner.name" ]]; then
+    echo '{"type": "User", "login": "owner.name"}'
+elif [[ "$URL" == *"repos/owner.name/repo.name" ]]; then
+    echo '{"name": "repo.name"}'
+elif [[ "$URL" == *"user" ]]; then
+    echo '{"login": "test-user"}'
+else
+    echo '{"message": "Not Found"}'
+fi
+exit 0
+EOF
+chmod +x mock-curl
+export PATH="$TEST_DIR:$PATH"
+# Use a script on PATH instead of a function, more reliable for subshells
+cp mock-curl curl
+
+# Mock git
+cat > mock-git <<'EOF'
+#!/usr/bin/env bash
+if [[ "$*" == "rev-parse --is-inside-work-tree" ]]; then
+    exit 1 # Not in a git repo for this test
+fi
+exit 0
+EOF
+chmod +x mock-git
+export PATH=".:$PATH"
+
+# Create repos.list with special characters
+# Use characters that are valid in components but might need encoding
+# NOTE: repo_path validation regex `^[^/]+/[^/]+$` prevents multiple slashes in owner/repo
+# So we use characters like # or dots or just one slash between owner and repo.
+# For owner and repo names, they are validated with `^[a-zA-Z0-9][a-zA-Z0-9._-]*$`
+# So we can't really have slashes IN owner or repo names according to the script's validation.
+# However, branch names CAN have slashes and are validated with `git check-ref-format`.
+cat > repos.list <<'EOF'
+owner.name/repo.name@branch/with/slash
+EOF
+
+# --- Run Test ---
+echo "Running create-repos.sh with special characters..."
+export GH_TOKEN="dummy_token"
+export GH_USER="dummy_user"
+
+# Run the script. We use 'bash' to run it to ensure the mock PATH is used
+# and we don't rely on the shebang if it might bypass our mock.
+# Actually, the script uses #!/usr/bin/env bash, so PATH mock should work.
+# We also want to check for stderr for the 'local' bug warning.
+bash "$CREATE_SCRIPT" -f repos.list > output.log 2> error.log || {
+    echo "FAILED: create-repos.sh exited with error"
+    cat error.log
+    exit 1
+}
+
+# --- Verification ---
+
+# 1. Check for 'local' bug warning in stderr
+if grep -q "local: can only be used in a function" error.log; then
+    echo "FAILED: 'local' keyword error found in stderr"
+    cat error.log
+    exit 1
+else
+    echo "PASSED: No 'local' keyword error found."
+fi
+
+# 2. Check curl calls for URL encoding
+# owner-with/slash -> owner-with%2Fslash
+# repo-with#hash -> repo-with%23hash
+# branch-with/slash -> branch-with%2Fslash
+
+echo "Verifying URL encoding in API calls..."
+if [ ! -f curl_calls.log ]; then
+    echo "FAILED: No curl calls logged"
+    exit 1
+fi
+
+# Expected URLs (normalised to what we expect mock-curl to receive)
+EXPECTED_USER_URL="https://api.github.com/users/owner.name"
+EXPECTED_REPO_URL="https://api.github.com/repos/owner.name/repo.name"
+EXPECTED_BRANCH_URL="https://api.github.com/repos/owner.name/repo.name/git/refs/heads/branch%2Fwith%2Fslash"
+
+# Check each expected URL in the log
+for url in "$EXPECTED_USER_URL" "$EXPECTED_REPO_URL" "$EXPECTED_BRANCH_URL"; do
+    if grep -qF "$url" curl_calls.log; then
+        echo "PASSED: Found encoded URL: $url"
+    else
+        echo "FAILED: Encoded URL not found in log: $url"
+        echo "Actual calls:"
+        cat curl_calls.log
+        exit 1
+    fi
+done
+
+echo "✅ All enhancement tests passed!"


### PR DESCRIPTION
🚨 Severity: LOW (Security Enhancement)
💡 Vulnerability: Direct interpolation of user-provided repository/branch names into GitHub API URL paths without encoding.
🎯 Impact: While primary validation is in place, branch names could contain URL metacharacters that might disrupt API requests or lead to unexpected path interpretation. Additionally, a `local` keyword bug caused potential script execution failure.
🔧 Fix: Added a `urlencode` helper using `jq` and applied it to all variable components in API URLs. Fixed Bash scope issue by replacing `local` with explicit variable initialization.
✅ Verification: Created `tests/test-create-repos-enhancements.sh` which mocks `curl` to verify correct URL encoding of parameters and successful script execution without Bash errors.

---
*PR created automatically by Jules for task [13613020580723381826](https://jules.google.com/task/13613020580723381826) started by @MiguelRodo*