### PR TITLE
🛡️ Sentinel: [security improvement] Secure worktree parsing

### DIFF
--- a/scripts/helper/clone-repos.sh
+++ b/scripts/helper/clone-repos.sh
@@ -535,10 +535,26 @@ ensure_wildcard_fetch_refspec() {
 }
 
 find_worktree_for_branch() {
-  local base="$1" branch="$2" line=""
-  if line="$(git -C "$base" worktree list 2>/dev/null | grep -F -e " [$branch]" | head -n1)"; then
-    printf '%s\n' "${line%% *}"
-  fi
+  local base="$1" branch="$2"
+  local current_worktree=""
+  local target_ref="refs/heads/$branch"
+
+  # Use git worktree list --porcelain for unambiguous parsing
+  # and to prevent pattern injection from directory paths.
+  while IFS= read -r line; do
+    case "$line" in
+      "worktree "*)
+        current_worktree="${line#worktree }"
+        ;;
+      "branch "*)
+        if [ "${line#branch }" = "$target_ref" ]; then
+          printf '%s\n' "$current_worktree"
+          return 0
+        fi
+        ;;
+    esac
+  done < <(git -C "$base" worktree list --porcelain 2>/dev/null)
+  return 1
 }
 
 # --- Parsing -----------------------------------------------------------------

--- a/scripts/update-branches.sh
+++ b/scripts/update-branches.sh
@@ -101,8 +101,8 @@ UPDATED_COUNT=0
 SKIPPED_COUNT=0
 
 while IFS= read -r line; do
-  # Parse worktree line: "path commit [branch]"
-  WORKTREE_PATH="${line%% *}"
+  # Parse worktree line from porcelain: "worktree <path>"
+  WORKTREE_PATH="${line#worktree }"
   
   # Skip the base repo (it will have bare or the repo path)
   if [ "$WORKTREE_PATH" = "$PROJECT_ROOT" ]; then
@@ -176,7 +176,7 @@ with open(os.environ['TMP_DEST'], 'w') as f:
   
   cd -- "$PROJECT_ROOT"
   
-done < <(git worktree list --porcelain | grep '^worktree' | sed 's/^worktree //')
+done < <(git worktree list --porcelain | grep '^worktree')
 
 echo ""
 echo "Summary:"


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Robustness and security issue in `git worktree list` parsing. Directory paths containing branch-like patterns (e.g., `/path/to/[main]/`) could lead to incorrect worktree identification. Additionally, paths containing spaces were truncated in `update-branches.sh`.
🎯 Impact: Potential misidentification of worktrees during repository setup or failure to update devcontainer configurations in worktrees with spaces in their paths.
🔧 Fix: Implemented unambiguous parsing using `git worktree list --porcelain` in both `clone-repos.sh` and `update-branches.sh`.
✅ Verification: Verified with custom test scripts mocking ambiguous output and paths with spaces. All 34 existing tests passed.

---
*PR created automatically by Jules for task [16083974018796853445](https://jules.google.com/task/16083974018796853445) started by @MiguelRodo*