### PR TITLE
🛡️ Sentinel: [security improvement] Strip credentials from normalized URLs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -65,6 +65,11 @@
 **Learning:** Glob patterns like `*../*..*` only catch multiple occurrences of `..` separated by a slash, and `../*` only catches `..` at the beginning followed by a slash. They do not cover all permutations of directory traversal.
 **Prevention:** Use a more comprehensive `case` pattern like `/*|..|*/..|../*|*/../*` to catch `..` in any position. If certain traversals are allowed (like a single level up for sibling repos), use explicit logic to validate that the path matches exactly the allowed pattern and nothing more.
 
+## 2025-06-14 - [Medium] Credential Leakage in Normalized Git URLs
+**Vulnerability:** Embedded credentials (e.g., `https://token@github.com/...`) in Git URLs were preserved during normalization in `normalise_remote_to_https`, leading to potential leakage in logs and workspace configuration files.
+**Learning:** Normalizing URLs for display or configuration must explicitly strip sensitive user information. Relying on Git to handle credentials internally is safer than passing them around in URL strings.
+**Prevention:** Use `sed` or similar tools to strip the `user:pass@` or `token@` part from HTTPS URLs before using them in any context that might be logged or stored in configuration files.
+
 ## 2029-05-18 - [Medium] Unintended Glob Expansion and Argument Injection in Codespaces Auth Helper
 **Vulnerability:** `scripts/helper/codespaces-auth-add.sh` was vulnerable to unintended glob expansion when processing repository overrides via the `-r` flag. Additionally, it lacked `--` separators in `mv`, `jq`, and `python` commands, making it susceptible to argument injection from filenames starting with a hyphen.
 **Learning:** Even in helper scripts, unquoted variable expansion during word-splitting or loop iteration can lead to globbing if not explicitly disabled. Furthermore, any command that accepts filenames must use the `--` separator to prevent those filenames from being interpreted as options.

--- a/scripts/helper/clone-repos.sh
+++ b/scripts/helper/clone-repos.sh
@@ -358,6 +358,9 @@ normalise_remote_to_https() {
       ;;
     https://*)
       url="${url%.git}"
+      # Strip embedded credentials (e.g. https://user:pass@host/...)
+      # to prevent leaking tokens in logs or workspace files.
+      url="$(printf '%s\n' "$url" | sed 's|^\(https://\)[^/]*@|\1|')"
       printf '%s\n' "$url"
       ;;
     ssh://git@*)

--- a/scripts/helper/codespaces-auth-add.sh
+++ b/scripts/helper/codespaces-auth-add.sh
@@ -174,6 +174,9 @@ normalise_remote_to_https() {
   case "$url" in
     https://*)
       url="${url%.git}"
+      # Strip embedded credentials (e.g. https://user:pass@host/...)
+      # to prevent leaking tokens in logs or workspace files.
+      url="$(printf '%s\n' "$url" | sed 's|^\(https://\)[^/]*@|\1|')"
       printf '%s\n' "$url"
       ;;
     ssh://git@*)

--- a/tests/test-security-token-stripping.sh
+++ b/tests/test-security-token-stripping.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# tests/test-security-token-stripping.sh
+# Verify that normalise_remote_to_https strips embedded credentials
+
+set -euo pipefail
+
+# Find the scripts
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)/scripts/helper"
+CLONE_SCRIPT="$SCRIPT_DIR/clone-repos.sh"
+AUTH_SCRIPT="$SCRIPT_DIR/codespaces-auth-add.sh"
+
+# Function to extract and run the normalise_remote_to_https function from a script
+test_normalization() {
+  local script_path="$1"
+  local test_url="$2"
+  local expected_url="$3"
+
+  # Extract the function using sed
+  # We look for the start and end of the function.
+  # This is fragile if the script structure changes significantly, but works for now.
+  local func_body
+  func_body=$(sed -n '/^normalise_remote_to_https() {/,/^}/p' "$script_path")
+
+  # Create a temporary script to run the function
+  local temp_script
+  temp_script=$(mktemp)
+  cat > "$temp_script" <<EOF
+#!/usr/bin/env bash
+$func_body
+normalise_remote_to_https "$test_url"
+EOF
+
+  local result
+  result=$(bash "$temp_script")
+  rm -f "$temp_script"
+
+  if [ "$result" = "$expected_url" ]; then
+    printf "  ✓ PASS: %s -> %s\n" "$test_url" "$result"
+    return 0
+  else
+    printf "  ✖ FAIL: %s -> %s (expected %s)\n" "$test_url" "$result" "$expected_url"
+    return 1
+  fi
+}
+
+FAILED=0
+
+echo "Testing token stripping in clone-repos.sh..."
+test_normalization "$CLONE_SCRIPT" "https://mytoken@github.com/owner/repo.git" "https://github.com/owner/repo" || FAILED=1
+test_normalization "$CLONE_SCRIPT" "https://user:pass@github.com/owner/repo" "https://github.com/owner/repo" || FAILED=1
+test_normalization "$CLONE_SCRIPT" "https://github.com/owner/repo.git" "https://github.com/owner/repo" || FAILED=1
+
+echo "Testing token stripping in codespaces-auth-add.sh..."
+test_normalization "$AUTH_SCRIPT" "https://mytoken@github.com/owner/repo.git" "https://github.com/owner/repo" || FAILED=1
+test_normalization "$AUTH_SCRIPT" "https://user:pass@github.com/owner/repo" "https://github.com/owner/repo" || FAILED=1
+
+if [ $FAILED -eq 0 ]; then
+  echo "All security normalization tests passed!"
+  exit 0
+else
+  echo "Security normalization tests failed!"
+  exit 1
+fi


### PR DESCRIPTION
🛡️ Sentinel: [security improvement]

🚨 Severity: MEDIUM

💡 Vulnerability: Embedded credentials (e.g., `https://token@github.com/...`) in Git URLs were preserved during normalization in helper scripts.

🎯 Impact: Sensitive tokens or passwords could be leaked in logs, repository configuration files, or the `entire-project.code-workspace` file where normalized URLs are stored.

🔧 Fix: Modified `normalise_remote_to_https` in `scripts/helper/clone-repos.sh` and `scripts/helper/codespaces-auth-add.sh` to strip the user information part of the URL using `sed`.

✅ Verification: Created `tests/test-security-token-stripping.sh` which extracts and runs the normalization function against URLs with tokens and passwords, verifying they are correctly stripped. Also ran the full test suite to ensure no regressions.

---
*PR created automatically by Jules for task [13740528630379607013](https://jules.google.com/task/13740528630379607013) started by @MiguelRodo*