### PR TITLE
🛡️ Sentinel: [security improvement] Strip credentials from http URLs

### DIFF
--- a/scripts/helper/clone-repos.sh
+++ b/scripts/helper/clone-repos.sh
@@ -356,11 +356,11 @@ normalise_remote_to_https() {
       url="${url%/}"
       printf '%s\n' "$url"
       ;;
-    https://*)
+    http://*|https://*)
       url="${url%.git}"
-      # Strip embedded credentials (e.g. https://user:pass@host/...)
+      # Strip embedded credentials (e.g. http://user:pass@host/...)
       # to prevent leaking tokens in logs or workspace files.
-      url="$(printf '%s\n' "$url" | sed 's|^\(https://\)[^/]*@|\1|')"
+      url="$(printf '%s\n' "$url" | sed 's|^\(https\?://\)[^/]*@|\1|')"
       printf '%s\n' "$url"
       ;;
     ssh://git@*)

--- a/scripts/helper/codespaces-auth-add.sh
+++ b/scripts/helper/codespaces-auth-add.sh
@@ -172,11 +172,11 @@ normalise_remote_to_https() {
   # Convert a remote URL to https://host/owner/repo (no .git)
   local url="$1" host path
   case "$url" in
-    https://*)
+    http://*|https://*)
       url="${url%.git}"
-      # Strip embedded credentials (e.g. https://user:pass@host/...)
+      # Strip embedded credentials (e.g. http://user:pass@host/...)
       # to prevent leaking tokens in logs or workspace files.
-      url="$(printf '%s\n' "$url" | sed 's|^\(https://\)[^/]*@|\1|')"
+      url="$(printf '%s\n' "$url" | sed 's|^\(https\?://\)[^/]*@|\1|')"
       printf '%s\n' "$url"
       ;;
     ssh://git@*)
@@ -403,7 +403,7 @@ build_raw_list(){
             repo_no_branch="${repo_no_branch%.git}"
             # Convert to https format
             case "$repo_no_branch" in
-              https://*|/*|[a-zA-Z]:/*|file://*)
+              http://*|https://*|/*|[a-zA-Z]:/*|file://*)
                 repo_https=$(normalise_remote_to_https "$repo_no_branch")
                 ;;
               */*)

--- a/tests/test-http-token-stripping.sh
+++ b/tests/test-http-token-stripping.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# tests/test-http-token-stripping.sh
+# Verifies that http:// URLs with embedded credentials are also stripped.
+
+set -euo pipefail
+
+# --- Paths ---
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CLONE_SCRIPT="$PROJECT_ROOT/scripts/helper/clone-repos.sh"
+AUTH_SCRIPT="$PROJECT_ROOT/scripts/helper/codespaces-auth-add.sh"
+
+# Load the scripts but only the normalization function
+# We can't easily source them because they call main
+# So we'll extract the function or use a wrapper
+
+test_normalise() {
+  local script="$1"
+  local input="$2"
+  local expected="$3"
+
+  # Extract the function and run it in a subshell
+  local result
+  result=$(bash -c "
+    $(sed -n '/^normalise_remote_to_https()/,/^}/p' "$script")
+    normalise_remote_to_https '$input'
+  ")
+
+  if [ "$result" = "$expected" ]; then
+    printf "  ✓ PASS: %s -> %s\n" "$input" "$result"
+  else
+    printf "  ✖ FAIL: %s -> %s (expected %s)\n" "$input" "$result" "$expected"
+    return 1
+  fi
+}
+
+echo "Testing http token stripping in clone-repos.sh..."
+test_normalise "$CLONE_SCRIPT" "http://mytoken@github.com/owner/repo.git" "http://github.com/owner/repo"
+test_normalise "$CLONE_SCRIPT" "http://user:pass@github.com/owner/repo" "http://github.com/owner/repo"
+
+echo "Testing http token stripping in codespaces-auth-add.sh..."
+test_normalise "$AUTH_SCRIPT" "http://mytoken@github.com/owner/repo.git" "http://github.com/owner/repo"
+test_normalise "$AUTH_SCRIPT" "http://user:pass@github.com/owner/repo" "http://github.com/owner/repo"
+
+echo "All http security normalization tests passed!"


### PR DESCRIPTION
### 🛡️ Sentinel: [security improvement] Strip credentials from http URLs

🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Git URLs using the `http` protocol with embedded credentials (e.g., `http://token@github.com/...`) were not having those credentials stripped during normalization.
🎯 **Impact:** Sensitive tokens or passwords could be leaked in logs, debug output, or configuration files (like the VS Code workspace file).
🔧 **Fix:** Updated the `normalise_remote_to_https` function in `scripts/helper/clone-repos.sh` and `scripts/helper/codespaces-auth-add.sh` to handle both `http://` and `https://` protocols when stripping credentials using `sed`. Also updated fallback detection in `codespaces-auth-add.sh` to recognize `http://` URLs.
✅ **Verification:** Verified with `tests/test-security-token-stripping.sh` and a new test script `tests/test-http-token-stripping.sh`. All security hardening tests pass.

---
*PR created automatically by Jules for task [4598331858787094223](https://jules.google.com/task/4598331858787094223) started by @MiguelRodo*