### PR TITLE
🛡️ Sentinel: [security improvement] harden shell scripts against argument injection

### DIFF
--- a/scripts/add-branch.sh
+++ b/scripts/add-branch.sh
@@ -20,7 +20,7 @@ export GIT_SSH_COMMAND="${GIT_SSH_COMMAND:-ssh -oBatchMode=yes}"
 git() { command git "$@" </dev/null; }
 
 # --- Paths ---
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname -- "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # --- Usage ---
@@ -138,7 +138,7 @@ sanitize_branch_name() {
 
 # --- Determine destination ---
 REPO_NAME="$(basename -- "$PROJECT_ROOT")"
-PARENT_DIR="$(dirname "$PROJECT_ROOT")"
+PARENT_DIR="$(dirname -- "$PROJECT_ROOT")"
 
 if [ -n "$TARGET_DIR" ]; then
   # Validate TARGET_DIR to prevent path traversal and argument injection

--- a/scripts/helper/clone-repos.sh
+++ b/scripts/helper/clone-repos.sh
@@ -1161,7 +1161,7 @@ main() {
 
   local start_dir parent_dir
   start_dir="$(pwd)"
-  parent_dir="$(dirname "$start_dir")"
+  parent_dir="$(dirname -- "$start_dir")"
 
   plan_forward "$REPOS_FILE" "$parent_dir" "$DEBUG"
 

--- a/scripts/helper/install-r-deps.sh
+++ b/scripts/helper/install-r-deps.sh
@@ -21,7 +21,7 @@ fi
 INVOKE_DIR="$PWD"
 
 # 2. Where this script lives (to locate the workspace file)
-SCRIPT_DIR="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
+SCRIPT_DIR="$(cd "$(dirname -- "$0")" >/dev/null 2>&1 && pwd)"
 
 # 3. Locate the workspace JSON (two levels up from scripts/helper/)
 WS1="$SCRIPT_DIR/../../entire-project.code-workspace"

--- a/scripts/run-pipeline.sh
+++ b/scripts/run-pipeline.sh
@@ -12,7 +12,7 @@
 set -Eeuo pipefail
 
 # --- Paths ---
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname -- "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 CLONE_SCRIPT="$SCRIPT_DIR/helper/clone-repos.sh"
 INSTALL_DEPS_SCRIPT="$SCRIPT_DIR/helper/install-r-deps.sh"
@@ -258,11 +258,11 @@ run_in_repo() {
     if [ -f "$target" ]; then
       printf "⏵ %s: %s found\n" "$repo_name" "$script_name"
       if $DRY_RUN; then
-        printf "  DRY-RUN: would chmod +x and execute %s\n" "$target"
+        printf "  DRY-RUN: would chmod -- +x and execute %s\n" "$target"
         record_success "$repo_name" "$script_name"
       else
-        $VERBOSE && printf "  chmod +x \"%s\"\n" "$target"
-        chmod +x "$target"
+        $VERBOSE && printf "  chmod -- +x \"%s\"\n" "$target"
+        chmod -- +x "$target"
         $VERBOSE && printf "  cd \"%s\" && ./%s\n" "$full_path" "$script_name"
         local rc=0
         ( cd -- "$full_path" && "./$script_name" ) || rc=$?

--- a/scripts/update-branches.sh
+++ b/scripts/update-branches.sh
@@ -15,7 +15,7 @@ export GIT_SSH_COMMAND="${GIT_SSH_COMMAND:-ssh -oBatchMode=yes}"
 git() { command git "$@" </dev/null; }
 
 # --- Paths ---
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname -- "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # --- Usage ---

--- a/scripts/update-scripts.sh
+++ b/scripts/update-scripts.sh
@@ -19,7 +19,7 @@ UPSTREAM_BRANCH="${UPSTREAM_BRANCH:-main}"
 SCRIPTS_SUBDIR="scripts"
 
 # --- Paths ---
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname -- "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 TARGET_DIR="$SCRIPT_DIR"
 
@@ -219,7 +219,7 @@ copy_scripts() {
     elif [ -f "$item" ]; then
       # Copy file and preserve permissions
       cp -- "$item" "$dst_dir/$item_name"
-      chmod +x -- "$dst_dir/$item_name"
+      chmod -- +x "$dst_dir/$item_name"
       printf '  ✓ Updated %s\n' "$rel_item"
     fi
   done

--- a/tests/test-security-hardening.sh
+++ b/tests/test-security-hardening.sh
@@ -77,7 +77,7 @@ cat > bin/Rscript <<'EOF'
 #!/bin/bash
 exit 0
 EOF
-chmod +x bin/Rscript
+chmod -- +x bin/Rscript
 export PATH="$PWD/bin:$PATH"
 
 # ============================================


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Shell commands like `dirname` and `chmod` were invoked with variable-based arguments without the `--` option terminator. This could allow an attacker to inject command-line flags if a path or filename starts with a hyphen.
🎯 Impact: Unintended command behavior or information leakage if user-controlled or external strings are interpreted as flags by these utilities.
🔧 Fix: Added the `--` option terminator to `dirname` and `chmod` calls across all relevant scripts. Standardized `chmod` calls to use `chmod -- +x "$file"` for consistent security and portability.
✅ Verification: Ran the full test suite, including `tests/test-security-hardening.sh`. All tests passed. Confirmed the presence of `--` in all modified files.

---
*PR created automatically by Jules for task [8156260116330622152](https://jules.google.com/task/8156260116330622152) started by @MiguelRodo*