### PR TITLE
docs: structure Quarto navigation and add syntax highlighting tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@ env/
 # Quarto
 _site/
 .quarto/
+quarto-1.4.550/
+quarto-1.4.550-linux-amd64.tar.gz
+
+/.quarto/

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -9,16 +9,20 @@ website:
         text: Home
       - href: install.qmd
         text: Installation
-      - href: repos-list.qmd
-        text: repos.list
-      - href: clone.qmd
-        text: repos clone
-      - href: vscode.qmd
-        text: VS Code
-      - href: pipelines.qmd
-        text: Pipelines
-      - href: worktrees.qmd
-        text: Worktrees
+      - text: "Reference/API"
+        menu:
+          - href: repos-list.qmd
+            text: repos.list
+          - href: clone.qmd
+            text: repos clone
+          - href: vscode.qmd
+            text: VS Code
+      - text: "Guides"
+        menu:
+          - href: pipelines.qmd
+            text: Pipelines
+          - href: worktrees.qmd
+            text: Worktrees
       - text: "Language Packages"
         menu:
           - href: python-package.qmd

--- a/clone.qmd
+++ b/clone.qmd
@@ -28,7 +28,7 @@ repos clone -f my-repos.list
 
 Repositories are cloned to the **parent** of your current directory:
 
-```
+```text
 workspace/
 ├── my-project/          # your project (contains repos.list)
 ├── backend/             # cloned from myorg/backend

--- a/index.qmd
+++ b/index.qmd
@@ -13,7 +13,7 @@ Manage multiple Git repositories as a unified workspace from a single `repos.lis
 Create a `repos.list` file in your project directory listing the repositories
 you want:
 
-```
+```text
 myorg/data-curation
 myorg/analysis
 myorg/documentation

--- a/python-package.qmd
+++ b/python-package.qmd
@@ -34,7 +34,7 @@ or WSL.
 Place a `repos.list` file in your project directory listing the repositories
 you want to manage (one per line):
 
-```
+```text
 myorg/data-curation
 myorg/analysis
 myorg/documentation

--- a/r-package.qmd
+++ b/r-package.qmd
@@ -26,7 +26,7 @@ your `PATH`.
 Place a `repos.list` file in your project directory listing the repositories
 you want to manage (one per line):
 
-```
+```text
 myorg/data-curation
 myorg/analysis
 myorg/documentation

--- a/repos-list.qmd
+++ b/repos-list.qmd
@@ -10,7 +10,7 @@ The `repos.list` file lists the repositories (and optionally branches) that
 
 Each line is one repository:
 
-```
+```text
 owner/repo
 ```
 
@@ -20,7 +20,7 @@ Lines starting with `#` are comments and are ignored.
 
 Append `@branch` to clone only that branch:
 
-```
+```text
 owner/repo@develop
 ```
 
@@ -28,7 +28,7 @@ owner/repo@develop
 
 Add a name after the repository to clone into a different directory:
 
-```
+```text
 owner/repo my-data
 ```
 
@@ -38,7 +38,7 @@ Use `@branch` without a repository name to clone only that branch from the most
 recently listed repository (or the current repository if none has been listed
 yet):
 
-```
+```text
 owner/repo
 @feature-x
 @bugfix-123
@@ -51,7 +51,7 @@ Add `--worktree` to an `@branch` line to create a
 [Git worktree](https://git-scm.com/docs/git-worktree) instead of a separate
 clone:
 
-```
+```text
 owner/repo
 @feature-x --worktree
 @bugfix-123 --worktree
@@ -64,7 +64,7 @@ clones required.
 
 Control whether new repositories are created as public or private:
 
-```
+```text
 owner/repo --public
 owner/other-repo --private
 ```
@@ -85,7 +85,7 @@ Per-line `--public`/`--private` flags always override the global default.
 
 ## Example
 
-```
+```text
 --private        # default visibility for new repos
 --codespaces     # set up Codespaces auth for all repos
 
@@ -97,7 +97,7 @@ myorg/docs --public        # override: create docs repo as public
 
 After `repos clone`, the parent directory looks like:
 
-```
+```text
 workspace/
 ├── my-project/            # your project (contains repos.list)
 ├── backend/

--- a/vscode.qmd
+++ b/vscode.qmd
@@ -42,7 +42,7 @@ repos workspace -f my-repos.list
 
 The workspace file reflects the repository layout in the parent directory:
 
-```
+```text
 workspace/
 ├── my-project/          # your project (contains repos.list)
 ├── backend/             # cloned from myorg/backend


### PR DESCRIPTION
This PR improves the Quarto documentation structure by grouping items into logical navbar menus (Reference/API, Guides, Language Packages) in `_quarto.yml`. It also ensures that all code blocks in `.qmd` files are properly tagged for syntax highlighting, using `text` for plain terminal/config output as instructed.

---
*PR created automatically by Jules for task [11823065365541305864](https://jules.google.com/task/11823065365541305864) started by @MiguelRodo*