### PR TITLE
🧪 [testing improvement] Add tests for update_scripts and update_scripts_raw

### DIFF
--- a/tests/test_update_scripts.py
+++ b/tests/test_update_scripts.py
@@ -1,0 +1,39 @@
+import pytest
+from unittest.mock import MagicMock
+import repos
+
+@pytest.fixture
+def mock_run_script(monkeypatch):
+    mock = MagicMock()
+    # Mock CompletedProcess
+    mock.return_value.returncode = 0
+    mock.return_value.stdout = ""
+    mock.return_value.stderr = ""
+    monkeypatch.setattr(repos, "run_script", mock)
+    return mock
+
+def test_update_scripts_no_args(mock_run_script):
+    repos.update_scripts()
+    mock_run_script.assert_called_once_with("update-scripts.sh", [])
+
+def test_update_scripts_branch(mock_run_script):
+    repos.update_scripts(branch="dev")
+    mock_run_script.assert_called_once_with("update-scripts.sh", ["--branch", "dev"])
+
+def test_update_scripts_dry_run(mock_run_script):
+    repos.update_scripts(dry_run=True)
+    mock_run_script.assert_called_once_with("update-scripts.sh", ["--dry-run"])
+
+def test_update_scripts_force(mock_run_script):
+    repos.update_scripts(force=True)
+    mock_run_script.assert_called_once_with("update-scripts.sh", ["--force"])
+
+def test_update_scripts_combined(mock_run_script):
+    repos.update_scripts(branch="feature", dry_run=True, force=True)
+    # The order of arguments depends on the implementation in repos/__init__.py
+    # From the code: branch then dry_run then force
+    mock_run_script.assert_called_once_with("update-scripts.sh", ["--branch", "feature", "--dry-run", "--force"])
+
+def test_update_scripts_raw(mock_run_script):
+    repos.update_scripts_raw("--branch", "main", "--force")
+    mock_run_script.assert_called_once_with("update-scripts.sh", ["--branch", "main", "--force"])


### PR DESCRIPTION
🎯 **What:** Addressed missing tests for `update_scripts` and `update_scripts_raw` functions in `src/repos/__init__.py`.

📊 **Coverage:** 
- `update_scripts()` with no arguments.
- `update_scripts()` with `branch`, `dry_run`, and `force` parameters (individually and combined).
- `update_scripts_raw()` with arbitrary positional arguments.
- Verification of correct script name and argument list passed to `run_script`.

✨ **Result:** Increased reliability and coverage of the Python wrapper by ensuring idiomatic and raw argument passing works as expected. The tests use the `pytest` framework and `unittest.mock` for isolation.

---
*PR created automatically by Jules for task [11613423319550151751](https://jules.google.com/task/11613423319550151751) started by @MiguelRodo*