### PR TITLE
🛡️ Sentinel: [Medium] Fix temporary log file persistence

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -100,6 +100,11 @@
 **Learning:** Error suppression with `trap` is dangerous in security-critical scripts as it masks failures in validation or authentication. Automated tests must be strictly isolated from the host's environment (e.g. `HOME`, `GIT_CONFIG_NOSYSTEM`) to ensure they truly verify the script's logic.
 **Prevention:** Avoid `trap '' ERR`. Capture script output to variables before processing with `grep` to avoid `SIGPIPE`. Use temporary `HOME` directories and `GIT_CONFIG_NOSYSTEM=1` for all tests involving Git authentication or configuration.
 
+## 2029-05-19 - [Medium] Temporary Log File Persistence
+**Vulnerability:** Auto-generated temporary debug files were not registered for cleanup, potentially leaving sensitive debug information on the filesystem after script execution.
+**Learning:** While the scripts used `mktemp` for secure creation, they failed to ensure these files were removed upon completion unless manually deleted by the user.
+**Prevention:** Use a global `CLEANUP_FILES` array and a `trap ... EXIT` routine to ensure all auto-generated temporary files are automatically removed. Always register `mktemp` outputs in this array if they are not intended to persist.
+
 ## 2025-07-15 - [High] Insecure Credential Parsing and Header Injection
 **Vulnerability:** `get_credentials` used `awk -F=` to parse `git credential fill` output, which truncated tokens containing equals signs. It also lacked CRLF sanitization for `GH_USER` and `GH_TOKEN` environment variables.
 **Learning:** Using a single character delimiter like `=` for parsing key-value pairs is fragile if the value itself can contain that delimiter. GitHub tokens frequently contain `=` characters. Lack of sanitization of user-provided environment variables in scripts that interact with web APIs can lead to header injection vulnerabilities.

--- a/scripts/helper/clone-repos.sh
+++ b/scripts/helper/clone-repos.sh
@@ -62,6 +62,12 @@ get_temp_dir() {
   fi
 }
 
+# Global array for temporary files to clean up on exit
+declare -a CLEANUP_FILES=()
+# Use Bash 3.2-safe array expansion to avoid "unbound variable" error with set -u
+# shellcheck disable=SC2154  # f is the for-loop variable inside the trap string
+trap 'for f in ${CLEANUP_FILES[@]+"${CLEANUP_FILES[@]}"}; do rm -f -- "$f"; done' EXIT
+
 # --- Planning & state (Bash 3.2-friendly) -----------------------------------
 # Remotes we've seen (normalised https), and where their local base lives
 declare -a SEEN_REMOTES=()
@@ -978,6 +984,7 @@ parse_args() {
           # Auto-generate debug file securely
           TEMP_DIR=$(get_temp_dir)
           DEBUG_FILE_ARG=$(mktemp "${TEMP_DIR}/repos-clone-debug-XXXXXX")
+          CLEANUP_FILES+=("$DEBUG_FILE_ARG")
         fi
         ;;
       -h|--help) usage; exit 0 ;;

--- a/scripts/helper/create-repos.sh
+++ b/scripts/helper/create-repos.sh
@@ -107,6 +107,7 @@ while [ $# -gt 0 ]; do
         # Auto-generate debug file securely
         TEMP_DIR=$(get_temp_dir)
         DEBUG_FILE=$(mktemp "${TEMP_DIR}/repos-create-debug-XXXXXX")
+        CLEANUP_FILES+=("$DEBUG_FILE")
       fi
       ;;
     -h|--help)    usage 0 ;;

--- a/scripts/helper/vscode-workspace-add.sh
+++ b/scripts/helper/vscode-workspace-add.sh
@@ -695,6 +695,7 @@ main() {
           # Auto-generate debug file securely
           TEMP_DIR=$(get_temp_dir)
           DEBUG_FILE=$(mktemp "${TEMP_DIR}/repos-workspace-debug-XXXXXX")
+          CLEANUP_FILES+=("$DEBUG_FILE")
         fi
         ;;
       -h|--help)


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Auto-generated temporary debug files were not registered for cleanup in `clone-repos.sh`, `create-repos.sh`, and `vscode-workspace-add.sh`.
🎯 Impact: Sensitive debug information could persist on the filesystem after script execution.
🔧 Fix: Implemented/updated a global `CLEANUP_FILES` array and a `trap ... EXIT` routine to automatically remove auto-generated temporary files upon script exit.
✅ Verification: Confirmed that auto-generated files are removed after execution, while manually specified files persist. Ran existing security test suite.

---
*PR created automatically by Jules for task [12116268878824451374](https://jules.google.com/task/12116268878824451374) started by @MiguelRodo*