### PR TITLE
Fix fragile JSONC parsing in codespaces-auth-add.sh

### DIFF
--- a/scripts/helper/codespaces-auth-add.sh
+++ b/scripts/helper/codespaces-auth-add.sh
@@ -512,19 +512,21 @@ update_with_python(){
 import sys, json, re, os
 
 def strip_jsonc(text):
-    # Match strings or comments.
-    # For single-line comments, we use [^\n]* to avoid matching across lines
-    # even when re.DOTALL is active.
-    pattern = re.compile(
-        r'(?P<string>"([^"\\\n]|\\.)*")|(?P<comment_ml>/\*.*?\*/)|(?P<comment_sl>//[^\n]*)|(?P<comma>,\s*(?=[}\]]))',
+    # Pass 1: Strip comments (multi-line and single-line)
+    # We must preserve strings to avoid stripping // inside URLs
+    comment_pattern = re.compile(
+        r'(?P<string>"([^"\\\n]|\\.)*")|(?P<comment_ml>/\*.*?\*/)|(?P<comment_sl>//[^\n]*)',
         re.DOTALL | re.MULTILINE
     )
-    def replace(match):
-        if match.group('string'):
-            return match.group('string')
-        else:
-            return ""
-    return pattern.sub(replace, text)
+    text = comment_pattern.sub(lambda m: m.group('string') if m.group('string') else "", text)
+
+    # Pass 2: Strip trailing commas
+    # Now that comments are gone, trailing commas are reliably followed by } or ]
+    comma_pattern = re.compile(
+        r'(?P<string>"([^"\\\n]|\\.)*")|(?P<comma>,\s*(?=[}\]]))',
+        re.DOTALL | re.MULTILINE
+    )
+    return comma_pattern.sub(lambda m: m.group('string') if m.group('string') else "", text)
 
 fname = sys.argv[1]
 repos_fname = sys.argv[2]

--- a/tests/test-codespaces-jsonc-fix.sh
+++ b/tests/test-codespaces-jsonc-fix.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# tests/test-codespaces-jsonc-fix.sh
+# Specifically tests the JSONC parsing logic in codespaces-auth-add.sh
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+print_test() {
+  echo -e "${YELLOW}TEST: $1${NC}"
+}
+
+print_pass() {
+  echo -e "${GREEN}✓ PASS: $1${NC}"
+}
+
+print_fail() {
+  echo -e "${RED}✗ FAIL: $1${NC}"
+  exit 1
+}
+
+# Project paths
+ORIG_PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CODESPACES_SCRIPT="$ORIG_PROJECT_ROOT/scripts/helper/codespaces-auth-add.sh"
+
+# Create temporary test directory
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+cd "$TEST_ROOT"
+
+# Mock git environment
+git init -q
+git config user.email "test@example.com"
+git config user.name "Test User"
+git remote add origin https://github.com/owner/repo
+
+# Create a problematic devcontainer.json with comments and trailing commas
+# Pattern 1: Trailing comma followed by a comment
+cat > devcontainer.json <<EOF
+{
+  "name": "Test Project",
+  "customizations": {
+    "codespaces": {
+      "repositories": {
+        "owner/existing": { "permissions": "read-all" }
+      }
+    }
+  }, // trailing comma here
+  // comment followed by closing brace
+}
+EOF
+
+# Create repos.list
+echo "owner/new" > repos.list
+
+print_test "Handling comments and trailing commas in devcontainer.json"
+
+# Run codespaces-auth-add.sh forcing python tool
+if ! bash "$CODESPACES_SCRIPT" -f repos.list -d devcontainer.json -t python3 >/dev/null 2>&1; then
+  # If python3 is not available, try python
+  if ! bash "$CODESPACES_SCRIPT" -f repos.list -d devcontainer.json -t python >/dev/null 2>&1; then
+     print_fail "codespaces-auth-add.sh failed to run"
+  fi
+fi
+
+# Verify JSON is still valid and has the new repository
+if ! command -v jq >/dev/null 2>&1; then
+  print_fail "jq is required for verification"
+fi
+
+if ! jq . devcontainer.json >/dev/null 2>&1; then
+  print_fail "Resulting devcontainer.json is not valid JSON"
+  cat devcontainer.json
+fi
+
+if jq -e '.customizations.codespaces.repositories["owner/new"]' devcontainer.json >/dev/null; then
+  print_pass "Successfully updated devcontainer.json with problematic JSONC patterns"
+else
+  print_fail "New repository not found in devcontainer.json"
+fi
+
+# Test Pattern 2: Multi-line comments
+cat > devcontainer.json <<EOF
+{
+  "name": "Test Project",
+  "customizations": {
+    "codespaces": {
+      "repositories": {
+        "owner/existing": { "permissions": "read-all" },
+      } /* multi-line
+         comment */
+    }
+  }
+}
+EOF
+
+if ! bash "$CODESPACES_SCRIPT" -f repos.list -d devcontainer.json -t python3 >/dev/null 2>&1; then
+  if ! bash "$CODESPACES_SCRIPT" -f repos.list -d devcontainer.json -t python >/dev/null 2>&1; then
+     print_fail "codespaces-auth-add.sh failed to run for Pattern 2"
+  fi
+fi
+
+if ! jq . devcontainer.json >/dev/null 2>&1; then
+  print_fail "Pattern 2: Resulting devcontainer.json is not valid JSON"
+  cat devcontainer.json
+fi
+
+if jq -e '.customizations.codespaces.repositories["owner/new"]' devcontainer.json >/dev/null; then
+  print_pass "Successfully handled multi-line comments and trailing commas"
+else
+  print_fail "Pattern 2: New repository not found"
+fi
+
+echo -e "${GREEN}All JSONC fix tests passed!${NC}"


### PR DESCRIPTION
Fixed a bug in `codespaces-auth-add.sh` where comments following trailing commas in `devcontainer.json` would cause the JSONC cleaner to fail, resulting in malformed JSON. Implemented a robust two-pass cleaning strategy and added comprehensive tests.

---
*PR created automatically by Jules for task [8097589050523562557](https://jules.google.com/task/8097589050523562557) started by @MiguelRodo*