### PR TITLE
🛡️ Sentinel: [Medium] Prevent GitHub token exposure in process list

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -29,7 +29,7 @@
 ## 2027-02-28 - [Medium] Insecure Shell Interpolation in jq Filters
 **Vulnerability:** Shell variables were interpolated directly into `jq` filter strings (e.g., `jq -r ".${field}"` or `if "'"$PERMISSIONS"'" == "all"`), potentially leading to injection vulnerabilities.
 **Learning:** Interpolating shell variables into `jq` filters is insecure as it allows the variable content to be parsed as part of the filter logic. Simple replacement with `.[$field]` also fails for nested paths (e.g., `commit.sha`).
-**Prevention:** Always use `jq`'s `--arg` or `--argjson` flags to pass values into the `jq` environment. For dynamic field access that may include nested paths, use `getpath($field | split("."))` to safely traverse the object.
+**Prevention:** Always use `jq`'s `--arg" or "--argjson" flags to pass values into the `jq` environment. For dynamic field access that may include nested paths, use `getpath($field | split("."))` to safely traverse the object.
 
 ## 2026-03-05 - [Medium] Argument Injection in Git Command Invocations
 **Vulnerability:** Git commands like `git clone`, `git worktree add`, and `git push` were invoked with user-provided or variable-based arguments (e.g., branch names or repository URLs) without the `--` separator. This allowed an attacker to inject command-line flags (e.g., using a branch name like `-h`).
@@ -119,3 +119,8 @@
 **Vulnerability:** User-provided target directory names and repository specifications were validated for path traversal but not for leading hyphens. This allowed for potential argument injection if these strings were passed to Git or other shell commands without the `--` separator.
 **Learning:** Hardening against argument injection requires two layers: (1) strict input validation to block metacharacters and leading hyphens, and (2) consistent use of the `--` option terminator in all command invocations. Encountering "Warning" instead of "Error" for unknown options in parsers can also mask injection attempts.
 **Prevention:** Always include `-*` in path and identifier validation `case` statements. Upgrade unknown option warnings to errors to "fail securely". Consistently apply `--` before any variable-based positional argument in Git, curl, awk, and other standard utilities.
+
+## 2026-04-23 - [Medium] Credential Exposure in Process Lists via Command-Line Headers
+**Vulnerability:** Passing authentication tokens (e.g., GitHub tokens) directly as command-line arguments to `curl` using the `-H` flag (e.g., `curl -H "Authorization: token $TOKEN"`) exposes the token in the system's process list (viewable via `ps`).
+**Learning:** While environment variables are generally safer than command-line arguments, many commands (including `curl`) allow passing sensitive data via files. This is the most secure method for local processes as it avoids exposure in the process table.
+**Prevention:** Use `curl`'s `@filename" syntax for headers (`-H @headerfile`) when passing sensitive data like tokens. Create the header file as a temporary file with restricted permissions (`600`) and ensure it is cleaned up on script exit.

--- a/scripts/helper/create-repos.sh
+++ b/scripts/helper/create-repos.sh
@@ -38,6 +38,9 @@ debug() {
   fi
 }
 
+# Global variable for the Authorization header file
+AUTH_HDR_FILE=""
+
 # Get platform-independent temp directory
 get_temp_dir() {
   # Try various temp directory variables in order of preference
@@ -197,7 +200,15 @@ get_credentials() {
     debug "Environment GH_TOKEN: ${GH_TOKEN:+<present>}"
   fi
 
-  debug "Credentials successfully obtained"
+  # Create a temporary file for the Authorization header to avoid exposing the token in process lists
+  if [ -z "$AUTH_HDR_FILE" ]; then
+    AUTH_HDR_FILE="$(mktemp "$(get_temp_dir)/repos-auth-hdr-XXXXXX")"
+    CLEANUP_FILES+=("$AUTH_HDR_FILE")
+    printf "Authorization: token %s\n" "$GH_TOKEN" > "$AUTH_HDR_FILE"
+    chmod 600 "$AUTH_HDR_FILE"
+  fi
+
+  debug "Credentials successfully obtained and header file created"
   return 0
 }
 
@@ -442,7 +453,7 @@ while IFS= read -r line || [ -n "$line" ]; do
         printf "Skipping branch check for @%s (no credentials)\n" "$branch"
         continue
       fi
-      AUTH_HDR="Authorization: token $GH_TOKEN"
+      AUTH_HDR="@$AUTH_HDR_FILE"
       
       # Validate token
       if ! validate_token "$AUTH_HDR"; then
@@ -557,7 +568,7 @@ while IFS= read -r line || [ -n "$line" ]; do
     debug "Line $line_num: Updated fallback to: $fallback_owner/$fallback_repo"
     continue
   fi
-  AUTH_HDR="Authorization: token $GH_TOKEN"
+  AUTH_HDR="@$AUTH_HDR_FILE"
 
   # Validate token before making API calls
   if ! validate_token "$AUTH_HDR"; then

--- a/tests/test-invalid-token.sh
+++ b/tests/test-invalid-token.sh
@@ -60,7 +60,7 @@ fi
 
 # Test 3: Verify the function is called after AUTH_HDR is set
 print_test "validate_token is called after AUTH_HDR is set"
-if grep -A5 'AUTH_HDR="Authorization: token' "$CREATE_SCRIPT" | grep -q 'validate_token'; then
+if grep -A5 'AUTH_HDR="@$AUTH_HDR_FILE"' "$CREATE_SCRIPT" | grep -q 'validate_token'; then
   print_pass "validate_token is called after setting AUTH_HDR"
 else
   print_fail "validate_token is not called after setting AUTH_HDR"


### PR DESCRIPTION
I have implemented a security enhancement in `scripts/helper/create-repos.sh` to prevent GitHub token exposure in system process lists.

### 🚨 Severity: MEDIUM

### 💡 Vulnerability
Passing sensitive credentials (like GitHub tokens) directly as command-line arguments to `curl` using the `-H` flag (e.g., `curl -H "Authorization: token $TOKEN"`) makes them visible to any user or process on the system that can view the process table (e.g., via `ps aux`).

### 🎯 Impact
An attacker with local access to the system (or a malicious process) could capture the GitHub token by monitoring the process list while the script is running. This token could then be used to gain unauthorized access to the user's GitHub account and repositories.

### 🔧 Fix
The script now stores the Authorization header in a temporary file with restricted permissions (`600`) using `mktemp`. All `curl` calls have been updated to use the `-H @filename` syntax, which instructs `curl` to read the header from the specified file instead of taking it from the command line. The temporary file is automatically deleted when the script exits.

### ✅ Verification
- Ran `tests/test-invalid-token.sh` (PASSED)
- Ran `tests/test-token-validation-unit.sh` (PASSED)
- Ran `tests/test-create-repos-security.sh` (PASSED)
- Ran `tests/test-create-repos-enhancements.sh` (PASSED)
- Manually verified that tokens are no longer visible in `ps` output during `curl` execution.
- Verified that functionality (cloning, branch creation, repo creation) remains intact.

---
*PR created automatically by Jules for task [7433484924693770566](https://jules.google.com/task/7433484924693770566) started by @MiguelRodo*