### PR TITLE
🛡️ Sentinel: [HIGH] Fix symlink dereference in update-scripts.sh

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -31,6 +31,11 @@
 **Learning:** Interpolating shell variables into `jq` filters is insecure as it allows the variable content to be parsed as part of the filter logic. Simple replacement with `.[$field]` also fails for nested paths (e.g., `commit.sha`).
 **Prevention:** Always use `jq`'s `--arg" or "--argjson" flags to pass values into the `jq` environment. For dynamic field access that may include nested paths, use `getpath($field | split("."))` to safely traverse the object.
 
+## 2024-05-07 - [High] Symlink Dereference in Upstream Script Updates
+**Vulnerability:** `scripts/update-scripts.sh` followed symbolic links when listing and copying files from an upstream repository.
+**Learning:** A malicious upstream repository could contain a symbolic link pointing to sensitive system files (e.g., `/etc/hostname`). The update script would dereference these links and copy the content of the linked files into the local repository, potentially leading to sensitive data leakage.
+**Prevention:** Explicitly check for and skip symbolic links in recursive file processing loops using `[ -L "$item" ] && continue`.
+
 ## 2026-03-05 - [Medium] Argument Injection in Git Command Invocations
 **Vulnerability:** Git commands like `git clone`, `git worktree add`, and `git push` were invoked with user-provided or variable-based arguments (e.g., branch names or repository URLs) without the `--` separator. This allowed an attacker to inject command-line flags (e.g., using a branch name like `-h`).
 **Learning:** Positional arguments that start with a hyphen can be interpreted as options by many Unix commands, including Git. Relying on variable expansion without termination of option parsing is a common source of argument injection.

--- a/scripts/update-scripts.sh
+++ b/scripts/update-scripts.sh
@@ -144,6 +144,8 @@ list_scripts() {
   
   for item in "$src_dir"/*; do
     [ ! -e "$item" ] && continue
+    # Skip symbolic links to prevent directory traversal and file leakage
+    [ -L "$item" ] && continue
     
     local item_name
     item_name="$(basename -- "$item")"
@@ -208,6 +210,8 @@ copy_scripts() {
   
   for item in "$src_dir"/*; do
     [ ! -e "$item" ] && continue
+    # Skip symbolic links to prevent directory traversal and file leakage
+    [ -L "$item" ] && continue
     
     local item_name
     item_name="$(basename -- "$item")"


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `scripts/update-scripts.sh` was following symbolic links when copying scripts from an upstream repository.
🎯 Impact: A malicious upstream repository could cause the script to leak sensitive system files (e.g., `/etc/hostname`) by including symlinks to them.
🔧 Fix: Added a check `[ -L "$item" ] && continue` in `list_scripts` and `copy_scripts` to skip symbolic links.
✅ Verification: Verified with a reproduction test script that simulates a malicious upstream with symlinks. The script correctly skipped the symlinks.

---
*PR created automatically by Jules for task [13146981177555776561](https://jules.google.com/task/13146981177555776561) started by @MiguelRodo*