### PR TITLE
🛡️ Sentinel: Harden git output and remove duplicate helpers

### DIFF
--- a/scripts/add-branch.sh
+++ b/scripts/add-branch.sh
@@ -17,7 +17,27 @@ export GIT_TERMINAL_PROMPT=0
 export GIT_ASKPASS=/bin/false
 export GIT_SSH_COMMAND="${GIT_SSH_COMMAND:-ssh -oBatchMode=yes}"
 
-git() { command git "$@" </dev/null; }
+# Strip credentials from any http(s) URLs
+sanitize_url() {
+  printf '%s\n' "$1" | sed 's|\(https\?://\)[^/@]*@|\1|g'
+}
+
+git() {
+  # Wrap git to capture and sanitize stderr to prevent credential leakage
+  # from git's own error messages (e.g. "fatal: could not read Password for 'https://token@github.com'")
+  local tmp_stderr
+  tmp_stderr="$(mktemp "$(get_temp_dir)/git-stderr-XXXXXX")"
+  CLEANUP_FILES+=("$tmp_stderr")
+
+  local rc=0
+  command git "$@" </dev/null 2>"$tmp_stderr" || rc=$?
+
+  if [ -s "$tmp_stderr" ]; then
+    sanitize_url "$(cat -- "$tmp_stderr")" >&2
+  fi
+  rm -f -- "$tmp_stderr"
+  return "$rc"
+}
 
 # --- Paths ---
 SCRIPT_DIR="$(cd "$(dirname -- "$0")" && pwd)"

--- a/scripts/helper/codespaces-auth-add.sh
+++ b/scripts/helper/codespaces-auth-add.sh
@@ -67,23 +67,6 @@ validate_devcontainer_path() {
   return 0
 }
 
-# Get platform-independent temp directory
-get_temp_dir() {
-  # Try various temp directory variables in order of preference
-  if [ -n "${TMPDIR:-}" ] && [ -d "${TMPDIR}" ]; then
-    printf '%s\n' "${TMPDIR%/}"  # Remove trailing slash if present
-  elif [ -n "${TEMP:-}" ] && [ -d "${TEMP}" ]; then
-    printf '%s\n' "${TEMP%/}"
-  elif [ -n "${TMP:-}" ] && [ -d "${TMP}" ]; then
-    printf '%s\n' "${TMP%/}"
-  elif [ -d "/tmp" ]; then
-    printf '%s\n' "/tmp"
-  else
-    # Fallback to current directory
-    printf '%s\n' "."
-  fi
-}
-
 # Global array for temporary files to clean up on exit
 declare -a CLEANUP_FILES=()
 # Use Bash 3.2-safe array expansion to avoid "unbound variable" error with set -u

--- a/scripts/helper/create-repos.sh
+++ b/scripts/helper/create-repos.sh
@@ -80,23 +80,6 @@ debug() {
 # Global variable for the Authorization header file
 AUTH_HDR_FILE=""
 
-# Get platform-independent temp directory
-get_temp_dir() {
-  # Try various temp directory variables in order of preference
-  if [ -n "${TMPDIR:-}" ] && [ -d "${TMPDIR}" ]; then
-    printf '%s\n' "${TMPDIR%/}"  # Remove trailing slash if present
-  elif [ -n "${TEMP:-}" ] && [ -d "${TEMP}" ]; then
-    printf '%s\n' "${TEMP%/}"
-  elif [ -n "${TMP:-}" ] && [ -d "${TMP}" ]; then
-    printf '%s\n' "${TMP%/}"
-  elif [ -d "/tmp" ]; then
-    printf '%s\n' "/tmp"
-  else
-    # Fallback to current directory
-    printf '%s\n' "."
-  fi
-}
-
 # URL encode a string using jq
 urlencode() {
   printf '%s' "$1" | jq -rR '@uri'

--- a/scripts/run-pipeline.sh
+++ b/scripts/run-pipeline.sh
@@ -11,9 +11,49 @@
 
 set -Eeuo pipefail
 
+# Get platform-independent temp directory
+get_temp_dir() {
+  # Try various temp directory variables in order of preference
+  if [ -n "${TMPDIR:-}" ] && [ -d "${TMPDIR}" ]; then
+    printf '%s\n' "${TMPDIR%/}"  # Remove trailing slash if present
+  elif [ -n "${TEMP:-}" ] && [ -d "${TEMP}" ]; then
+    printf '%s\n' "${TEMP%/}"
+  elif [ -n "${TMP:-}" ] && [ -d "${TMP}" ]; then
+    printf '%s\n' "${TMP%/}"
+  elif [ -d "/tmp" ]; then
+    printf '%s\n' "/tmp"
+  else
+    # Fallback to current directory
+    printf '%s\n' "."
+  fi
+}
+
 # Strip credentials from any http(s) URLs
 sanitize_url() {
   printf '%s\n' "$1" | sed 's|\(https\?://\)[^/@]*@|\1|g'
+}
+
+# Global array for temporary files to clean up on exit
+declare -a CLEANUP_FILES=()
+# Use Bash 3.2-safe array expansion to avoid "unbound variable" error with set -u
+# shellcheck disable=SC2154  # f is the for-loop variable inside the trap string
+trap 'for f in ${CLEANUP_FILES[@]+"${CLEANUP_FILES[@]}"}; do rm -f -- "$f"; done' EXIT
+
+git() {
+  # Wrap git to capture and sanitize stderr to prevent credential leakage
+  # from git's own error messages (e.g. "fatal: could not read Password for 'https://token@github.com'")
+  local tmp_stderr
+  tmp_stderr="$(mktemp "$(get_temp_dir)/git-stderr-XXXXXX")"
+  CLEANUP_FILES+=("$tmp_stderr")
+
+  local rc=0
+  command git "$@" </dev/null 2>"$tmp_stderr" || rc=$?
+
+  if [ -s "$tmp_stderr" ]; then
+    sanitize_url "$(cat -- "$tmp_stderr")" >&2
+  fi
+  rm -f -- "$tmp_stderr"
+  return "$rc"
 }
 
 # --- Paths ---

--- a/scripts/update-branches.sh
+++ b/scripts/update-branches.sh
@@ -12,7 +12,27 @@ export GIT_TERMINAL_PROMPT=0
 export GIT_ASKPASS=/bin/false
 export GIT_SSH_COMMAND="${GIT_SSH_COMMAND:-ssh -oBatchMode=yes}"
 
-git() { command git "$@" </dev/null; }
+# Strip credentials from any http(s) URLs
+sanitize_url() {
+  printf '%s\n' "$1" | sed 's|\(https\?://\)[^/@]*@|\1|g'
+}
+
+git() {
+  # Wrap git to capture and sanitize stderr to prevent credential leakage
+  # from git's own error messages (e.g. "fatal: could not read Password for 'https://token@github.com'")
+  local tmp_stderr
+  tmp_stderr="$(mktemp "$(get_temp_dir)/git-stderr-XXXXXX")"
+  CLEANUP_FILES+=("$tmp_stderr")
+
+  local rc=0
+  command git "$@" </dev/null 2>"$tmp_stderr" || rc=$?
+
+  if [ -s "$tmp_stderr" ]; then
+    sanitize_url "$(cat -- "$tmp_stderr")" >&2
+  fi
+  rm -f -- "$tmp_stderr"
+  return "$rc"
+}
 
 # --- Paths ---
 SCRIPT_DIR="$(cd "$(dirname -- "$0")" && pwd)"

--- a/scripts/update-scripts.sh
+++ b/scripts/update-scripts.sh
@@ -11,7 +11,58 @@ export GIT_TERMINAL_PROMPT=0
 export GIT_ASKPASS=/bin/false
 export GIT_SSH_COMMAND="${GIT_SSH_COMMAND:-ssh -oBatchMode=yes}"
 
-git() { command git "$@" </dev/null; }
+# Get platform-independent temp directory
+get_temp_dir() {
+  # Try various temp directory variables in order of preference
+  if [ -n "${TMPDIR:-}" ] && [ -d "${TMPDIR}" ]; then
+    printf '%s\n' "${TMPDIR%/}"  # Remove trailing slash if present
+  elif [ -n "${TEMP:-}" ] && [ -d "${TEMP}" ]; then
+    printf '%s\n' "${TEMP%/}"
+  elif [ -n "${TMP:-}" ] && [ -d "${TMP}" ]; then
+    printf '%s\n' "${TMP%/}"
+  elif [ -d "/tmp" ]; then
+    printf '%s\n' "/tmp"
+  else
+    # Fallback to current directory
+    printf '%s\n' "."
+  fi
+}
+
+# Strip credentials from any http(s) URLs
+sanitize_url() {
+  printf '%s\n' "$1" | sed 's|\(https\?://\)[^/@]*@|\1|g'
+}
+
+# Global array for temporary files to clean up on exit
+declare -a CLEANUP_FILES=()
+# Use Bash 3.2-safe array expansion to avoid "unbound variable" error with set -u
+# shellcheck disable=SC2154  # f is the for-loop variable inside the trap string
+cleanup() {
+  for f in ${CLEANUP_FILES[@]+"${CLEANUP_FILES[@]}"}; do
+    rm -f -- "$f"
+  done
+  if [ -n "${TEMP_DIR:-}" ] && [ -d "$TEMP_DIR" ]; then
+    rm -rf -- "$TEMP_DIR"
+  fi
+}
+trap cleanup EXIT
+
+git() {
+  # Wrap git to capture and sanitize stderr to prevent credential leakage
+  # from git's own error messages (e.g. "fatal: could not read Password for 'https://token@github.com'")
+  local tmp_stderr
+  tmp_stderr="$(mktemp "$(get_temp_dir)/git-stderr-XXXXXX")"
+  CLEANUP_FILES+=("$tmp_stderr")
+
+  local rc=0
+  command git "$@" </dev/null 2>"$tmp_stderr" || rc=$?
+
+  if [ -s "$tmp_stderr" ]; then
+    sanitize_url "$(cat -- "$tmp_stderr")" >&2
+  fi
+  rm -f -- "$tmp_stderr"
+  return "$rc"
+}
 
 # --- Configuration ---
 UPSTREAM_REPO="${UPSTREAM_REPO:-https://github.com/MiguelRodo/CompTemplate.git}"
@@ -111,7 +162,6 @@ fi
 # --- Create temp directory ---
 # Use mktemp without -- for portability with BSD/macOS
 TEMP_DIR="$(mktemp -d)"
-trap 'rm -rf -- "$TEMP_DIR"' EXIT
 
 printf 'Fetching scripts from %s (branch: %s)...\n' "$UPSTREAM_REPO" "$UPSTREAM_BRANCH"
 

--- a/test_bash_array.sh
+++ b/test_bash_array.sh
@@ -1,6 +1,0 @@
-set -u
-arr=()
-echo "Start"
-# This would fail on Bash 3.2
-echo "${arr[@]}"
-echo "End"

--- a/test_bash_array_fix.sh
+++ b/test_bash_array_fix.sh
@@ -1,6 +1,0 @@
-set -u
-arr=()
-echo "Length: ${#arr[@]}"
-# This SHOULD NOT fail even in Bash 3.2 with set -u
-echo ${arr[@]+"${arr[@]}"}
-echo "End"


### PR DESCRIPTION
🛡️ Sentinel: Harden git output and remove duplicate helpers

🚨 Severity: MEDIUM
💡 Vulnerability: Potential credential leakage in git error messages and minor code duplication.
🎯 Impact: Sensitive tokens embedded in repository URLs could be leaked to terminal output or logs if a git command fails. Duplicate code makes maintenance harder and could lead to inconsistent security posture.
🔧 Fix: Implemented a robust `git()` wrapper across all core scripts to capture and sanitize `stderr`. Removed duplicate `get_temp_dir` definitions from helper scripts.
✅ Verification: Ran `tests/test-credential-leak-sentinel.sh` and other integration tests; all passed. Verified standalone functionality of each script.

---
*PR created automatically by Jules for task [13339955392216811613](https://jules.google.com/task/13339955392216811613) started by @MiguelRodo*