### PR TITLE
Update AGENTS.md for Pure Go transition

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,19 +6,27 @@ Configuration for AI coding agents (e.g., Google Jules, GitHub Copilot) working 
 
 ## Core Philosophy / Project Context
 
-`repos` is a command-line tool for managing multiple related Git repositories as a unified workspace. The primary workflow is:
+`repos` is a command-line tool for managing multiple related Git repositories as a unified workspace.
 
+### Transition to Pure Go
+Historically, this project was built on Bash 3.2-compatible scripts (designed to work in environments like Git Bash on Windows) with a CLI frontend and language wrappers (R and Python) that shelled out to those scripts.
+
+**We are actively transitioning to a pure Go implementation (`cmd/repos/`).**
+
+When modifying or extending the tool:
+- **Do NOT use or shell out to the legacy shell scripts** in the `scripts/` directory from the Go code.
+- The Go commands must be fully self-contained and implemented in pure Go (with the exception of shelling out to `git` or `gh` where unavoidable, though native Go solutions are preferred when practical).
+- Do not rely on external tools like `jq`, `curl`, Python, or R inside the Go codebase. Use standard Go libraries (e.g., `encoding/json`, `net/http`).
+
+### Documentation
+- The `README.md` provides a concise overview of the project.
+- Detailed documentation is available on the project's website, which is structured with roughly one page per command (e.g., `clone.qmd`, `install.qmd`, `pipelines.qmd`, `worktrees.qmd`). Consult these files for intended user-facing behavior.
+
+### Key Architectural Patterns
 1. A user creates a `repos.list` file listing repositories (and optionally branches) they want cloned.
-2. Running `repos clone` clones them all into the **parent directory** of the current location, creating the remote repositories on GitHub (via the API) if they do not already exist.
-3. Running `repos run` executes a script inside each cloned repository.
-
-The codebase is built around **Bash scripts** as the core engine. Language wrappers (R and Python) exist to expose the same functionality from those runtimes by bundling and invoking the Bash scripts via `system2()` / `subprocess.run()`.
-
-Key architectural patterns:
-- All real logic lives in `scripts/` (and `scripts/helper/`); the top-level `bin/repos` dispatcher delegates to them.
-- Repositories are always cloned to the **parent directory** of the working directory — never inside it.
-- Branch-only clones use Git **worktrees**, not fresh clones.
-- Fallback repository logic: a bare `@<branch>` line reuses the most recently seen repo (or the current repo's remote if none has been seen yet).
+2. Repositories are always cloned to the **parent directory** of the working directory — never inside it.
+3. Branch-only clones use Git **worktrees** rather than fresh full clones to save space and simplify management.
+4. Fallback repository logic: a bare `@<branch>` line reuses the most recently seen repo (or the current repo's remote if none has been seen yet).
 
 ---
 
@@ -27,137 +35,58 @@ Key architectural patterns:
 ### Core
 | Layer | Technology |
 |---|---|
-| Shell | **Bash** (POSIX-compatible where possible) |
+| CLI Application | **Go** (`cmd/repos/`) |
 | VCS | **Git** (including `git worktree`) |
-| HTTP / GitHub API | **curl** + **jq** |
 | GitHub auth | `GH_TOKEN` env var or `gh` CLI |
 
-### Language Wrappers
+### Legacy Wrappers (Transitioning)
 | Language | Entry point |
 |---|---|
+| Shell | `scripts/` (Legacy core logic) |
 | R | `R/` package; functions in `R/repos.R` |
 | Python | `src/repos/` package; entry point `src/repos/__init__.py` |
-
-### Packaging
-| Platform | Format |
-|---|---|
-| Ubuntu / Debian | `.deb` (built with `dpkg-buildpackage`) |
-| macOS | Homebrew formula (`homebrew/`) |
-| Windows | Scoop manifest (`scoop/`) |
-| Language | pip (`pyproject.toml`), devtools/GitHub (`DESCRIPTION`) |
-
-### Do **not** use
-- Any shell other than Bash for new scripts (avoid `zsh`-only or `fish` syntax).
-- Python or R for core logic — keep the Bash scripts as the single source of truth.
-- External tools beyond `bash`, `git`, `curl`, and `jq` as hard runtime dependencies.
-
----
-
-## Setup Commands
-
-```bash
-# Clone the repository
-git clone https://github.com/MiguelRodo/repos.git
-cd repos
-
-# Install to ~/.local/bin (no sudo required)
-bash install-local.sh
-
-# Verify installation
-repos --help
-```
-
-If `~/.local/bin` is not on your `PATH`:
-
-```bash
-export PATH="$HOME/.local/bin:$PATH"
-# Persist by adding the line above to ~/.bashrc or ~/.profile
-```
-
-### Runtime dependencies
-
-```bash
-# Ubuntu / Debian
-sudo apt-get install bash git curl jq
-
-# macOS (Homebrew)
-brew install git curl jq
-```
 
 ---
 
 ## Build & Test Instructions
 
-### Running the test suite
+### Running the Go Tests
 
-Tests are plain Bash scripts located in `tests/`. Run them individually or all at once:
+All new functionality should be covered by Go tests.
 
 ```bash
-# Run a specific test
-bash tests/test-clone-variations-comprehensive.sh
+# Run the Go test suite
+cd cmd/repos
+go test ./... -v
+```
 
-# Run all tests (from the repo root)
+### Legacy Shell Tests
+There are still legacy Bash tests in `tests/` which ensure the old scripts (and sometimes the Go binaries) function correctly. Run them using:
+
+```bash
+# Run all legacy tests (from the repo root)
 for t in tests/test-*.sh; do
   echo "==> $t"
   bash "$t"
 done
 ```
 
-Notable test files:
-| File | What it covers |
-|---|---|
-| `tests/test-local-repo-comprehensive.sh` | Full integration test using local bare git remotes (no network required) |
-| `tests/test-auth-check.sh` | GitHub token validation logic |
-| `tests/test-clone-repos-flags.sh` | Flag handling in `clone-repos.sh` |
-| `tests/test-worktree-tracking.sh` | Worktree creation and tracking |
-
-### Linting / static analysis
-
-No automated linter is currently configured in CI/CD. When editing Bash scripts, follow `shellcheck` best practices:
-
-```bash
-# Install shellcheck
-sudo apt-get install shellcheck   # Ubuntu/Debian
-brew install shellcheck           # macOS
-
-# Lint a script
-shellcheck scripts/run-pipeline.sh
-shellcheck scripts/helper/clone-repos.sh
-```
-
-### Python package (optional)
-
-```bash
-pip install -e .          # Install in editable mode
-python -c "from repos import setup; print('ok')"
-```
-
-### R package (optional)
-
-```r
-devtools::load_all()      # Load package for development
-devtools::test()          # Run R tests (if any)
-```
-
 ---
 
 ## Coding Style & Conventions
 
-### Bash scripts
-- Use `set -e` at the top of every script to fail fast on errors.
-- Use `mktemp` (never predictable `/tmp/$name_$$`) for temporary files.
-- Quote all variable expansions: `"$var"`, `"${arr[@]}"`.
-- Use `local` for variables inside functions.
-- Sanitize filesystem names derived from branch names by replacing `/` with `-` (e.g., `feature/x` → `feature-x` for directory names, while the actual git branch name is preserved).
-- Add a brief comment header at the top of each script describing its purpose.
+### Go Code
+- Follow standard Go idioms and formatting (`gofmt`).
+- Ensure robust error handling. Do not silently ignore errors unless explicitly documented why.
+- Keep commands encapsulated in their respective files (e.g., `clone.go`, `create.go`, `run.go`).
 
-### Git commits
+### Git Commits
 - Use the imperative mood in the subject line: *"Add flag for --public"*, not *"Added …"*.
 - Keep the subject line under 72 characters.
 - Reference the relevant issue or PR where applicable.
 
-### Pull requests
+### Pull Requests
 - One logical change per PR.
 - All existing tests must pass before merging.
-- Add or update tests in `tests/` when changing script behaviour.
-- Do not introduce new runtime dependencies without updating the *Dependencies* section in `README.md`.
+- Add or update tests when changing behavior.
+- Ensure the changes adhere to the "Pure Go" mandate for the CLI.


### PR DESCRIPTION
Updates `AGENTS.md` to instruct AI agents about the project's transition from legacy Bash 3.2-compatible scripts to a pure Go implementation in `cmd/repos/`. It explicitly forbids shelling out to the legacy scripts or using external dependencies like `jq`, `curl`, `python`, or `Rscript` in the new Go commands. It also highlights the concise README and the command-specific website documentation.

---
*PR created automatically by Jules for task [7576284606220965507](https://jules.google.com/task/7576284606220965507) started by @MiguelRodo*