### PR TITLE
🛡️ Sentinel: [MEDIUM] Harden temporary file creation with restrictive umask

### DIFF
--- a/scripts/add-branch.sh
+++ b/scripts/add-branch.sh
@@ -26,7 +26,7 @@ git() {
   # Wrap git to capture and sanitize stderr to prevent credential leakage
   # from git's own error messages (e.g. "fatal: could not read Password for 'https://token@github.com'")
   local tmp_stderr
-  tmp_stderr="$(mktemp "$(get_temp_dir)/git-stderr-XXXXXX")"
+  tmp_stderr="$(umask 077 && mktemp "$(get_temp_dir)/git-stderr-XXXXXX")"
   CLEANUP_FILES+=("$tmp_stderr")
 
   local rc=0
@@ -265,13 +265,13 @@ if [ -f ".devcontainer/prebuild/devcontainer.json" ]; then
   # Remove the repositories section if it exists (using multiple approaches for portability)
   if command -v jq >/dev/null 2>&1; then
     # Use jq if available (reads directly from file)
-    tmp_dest=$(mktemp "$(get_temp_dir)/add-branch-XXXXXX")
+    tmp_dest=$(umask 077 && mktemp "$(get_temp_dir)/add-branch-XXXXXX")
     CLEANUP_FILES+=("$tmp_dest")
     jq 'del(.customizations.codespaces.repositories)' -- "$PREBUILD_FILE" > "$tmp_dest" && mv -- "$tmp_dest" "$DEST_FILE"
   elif command -v python3 >/dev/null 2>&1; then
     # Use Python if available (reads directly from file via env var)
     export PREBUILD_FILE DEST_FILE
-    tmp_dest=$(mktemp "$(get_temp_dir)/add-branch-XXXXXX")
+    tmp_dest=$(umask 077 && mktemp "$(get_temp_dir)/add-branch-XXXXXX")
     CLEANUP_FILES+=("$tmp_dest")
     export tmp_dest
     python3 -c "

--- a/scripts/helper/clone-repos.sh
+++ b/scripts/helper/clone-repos.sh
@@ -63,7 +63,7 @@ git() {
   # Wrap git to capture and sanitize stderr to prevent credential leakage
   # from git's own error messages (e.g. "fatal: could not read Password for 'https://token@github.com'")
   local tmp_stderr
-  tmp_stderr="$(mktemp "$(get_temp_dir)/git-stderr-XXXXXX")"
+  tmp_stderr="$(umask 077 && mktemp "$(get_temp_dir)/git-stderr-XXXXXX")"
   CLEANUP_FILES+=("$tmp_stderr")
 
   local rc=0
@@ -1284,7 +1284,7 @@ parse_args() {
         else
           # Auto-generate debug file securely
           TEMP_DIR=$(get_temp_dir)
-          DEBUG_FILE_ARG=$(mktemp "${TEMP_DIR}/repos-clone-debug-XXXXXX")
+          DEBUG_FILE_ARG=$(umask 077 && mktemp "${TEMP_DIR}/repos-clone-debug-XXXXXX")
           CLEANUP_FILES+=("$DEBUG_FILE_ARG")
         fi
         ;;

--- a/scripts/helper/codespaces-auth-add.sh
+++ b/scripts/helper/codespaces-auth-add.sh
@@ -39,7 +39,7 @@ git() {
   # Wrap git to capture and sanitize stderr to prevent credential leakage
   # from git's own error messages (e.g. "fatal: could not read Password for 'https://token@github.com'")
   local tmp_stderr
-  tmp_stderr="$(mktemp "$(get_temp_dir)/git-stderr-XXXXXX")"
+  tmp_stderr="$(umask 077 && mktemp "$(get_temp_dir)/git-stderr-XXXXXX")"
   CLEANUP_FILES+=("$tmp_stderr")
 
   local rc=0
@@ -497,7 +497,7 @@ filter_valid_list(){
 build_repos_json_file(){
   local output_file="$1"
   local valid_list_file
-  valid_list_file="$(mktemp "$(get_temp_dir)/repos-valid-list-XXXXXX")"
+  valid_list_file="$(umask 077 && mktemp "$(get_temp_dir)/repos-valid-list-XXXXXX")"
   CLEANUP_FILES+=("$valid_list_file")
   printf '%s\n' "$VALID_LIST" > "$valid_list_file"
 
@@ -533,7 +533,7 @@ update_with_jq(){
   local file="$1"
   local repos_file=""
 
-  repos_file="$(mktemp "$(get_temp_dir)/repos-json-XXXXXX")"
+  repos_file="$(umask 077 && mktemp "$(get_temp_dir)/repos-json-XXXXXX")"
   CLEANUP_FILES+=("$repos_file")
   build_repos_json_file "$repos_file"
 
@@ -557,7 +557,7 @@ update_with_python(){
   local py_cmd="${2:-python}"
   local repos_file=""
 
-  repos_file="$(mktemp "$(get_temp_dir)/repos-json-XXXXXX")"
+  repos_file="$(umask 077 && mktemp "$(get_temp_dir)/repos-json-XXXXXX")"
   CLEANUP_FILES+=("$repos_file")
   build_repos_json_file "$repos_file"
 
@@ -622,7 +622,7 @@ update_with_rscript(){
   local file="$1"
   local repos_file=""
 
-  repos_file="$(mktemp "$(get_temp_dir)/repos-json-XXXXXX")"
+  repos_file="$(umask 077 && mktemp "$(get_temp_dir)/repos-json-XXXXXX")"
   CLEANUP_FILES+=("$repos_file")
   build_repos_json_file "$repos_file"
 
@@ -693,7 +693,7 @@ update_devfile(){
   else
     # Safely write via a temporary file, then move into place
     local tmp=""
-    tmp="$(mktemp "$(get_temp_dir)/repos-auth-XXXXXX")"
+    tmp="$(umask 077 && mktemp "$(get_temp_dir)/repos-auth-XXXXXX")"
     CLEANUP_FILES+=("$tmp")
 
     local rc=0

--- a/scripts/helper/create-repos.sh
+++ b/scripts/helper/create-repos.sh
@@ -37,7 +37,7 @@ git() {
   # Wrap git to capture and sanitize stderr to prevent credential leakage
   # from git's own error messages (e.g. "fatal: could not read Password for 'https://token@github.com'")
   local tmp_stderr
-  tmp_stderr="$(mktemp "$(get_temp_dir)/git-stderr-XXXXXX")"
+  tmp_stderr="$(umask 077 && mktemp "$(get_temp_dir)/git-stderr-XXXXXX")"
   CLEANUP_FILES+=("$tmp_stderr")
 
   local rc=0
@@ -165,7 +165,7 @@ while [ $# -gt 0 ]; do
       else
         # Auto-generate debug file securely
         TEMP_DIR=$(get_temp_dir)
-        DEBUG_FILE=$(mktemp "${TEMP_DIR}/repos-create-debug-XXXXXX")
+        DEBUG_FILE=$(umask 077 && mktemp "${TEMP_DIR}/repos-create-debug-XXXXXX")
         CLEANUP_FILES+=("$DEBUG_FILE")
       fi
       ;;
@@ -258,10 +258,9 @@ get_credentials() {
 
   # Create a temporary file for the Authorization header to avoid exposing the token in process lists
   if [ -z "$AUTH_HDR_FILE" ]; then
-    AUTH_HDR_FILE="$(mktemp "$(get_temp_dir)/repos-auth-hdr-XXXXXX")"
+    AUTH_HDR_FILE="$(umask 077 && mktemp "$(get_temp_dir)/repos-auth-hdr-XXXXXX")"
     CLEANUP_FILES+=("$AUTH_HDR_FILE")
     printf "Authorization: token %s\n" "$GH_TOKEN" > "$AUTH_HDR_FILE"
-    chmod 600 "$AUTH_HDR_FILE"
   fi
 
   debug "Credentials successfully obtained and header file created"
@@ -278,7 +277,7 @@ validate_token() {
   debug "Validating GitHub token..."
   
   local response_file
-  response_file="$(mktemp "$(get_temp_dir)/repos-token-val-XXXXXX")"
+  response_file="$(umask 077 && mktemp "$(get_temp_dir)/repos-token-val-XXXXXX")"
   CLEANUP_FILES+=("$response_file")
 
   # Make a simple API call to check token validity

--- a/scripts/helper/vscode-workspace-add.sh
+++ b/scripts/helper/vscode-workspace-add.sh
@@ -112,9 +112,9 @@ update_with_jq() {
   local folders_json_file=""
   local paths_list_file=""
 
-  folders_json_file="$(mktemp "$(get_temp_dir)/repos-folders-XXXXXX")"
+  folders_json_file="$(umask 077 && mktemp "$(get_temp_dir)/repos-folders-XXXXXX")"
   CLEANUP_FILES+=("$folders_json_file")
-  paths_list_file="$(mktemp "$(get_temp_dir)/repos-paths-list-XXXXXX")"
+  paths_list_file="$(umask 077 && mktemp "$(get_temp_dir)/repos-paths-list-XXXXXX")"
   CLEANUP_FILES+=("$paths_list_file")
 
   printf '%s\n' "$paths_list" > "$paths_list_file"
@@ -144,7 +144,7 @@ update_with_python() {
   local py_cmd="${3:-python}"
   local paths_file=""
 
-  paths_file="$(mktemp "$(get_temp_dir)/repos-paths-XXXXXX")"
+  paths_file="$(umask 077 && mktemp "$(get_temp_dir)/repos-paths-XXXXXX")"
   CLEANUP_FILES+=("$paths_file")
   printf '%s\n' "$paths_list" > "$paths_file"
 
@@ -176,7 +176,7 @@ update_with_rscript() {
   local paths_list="$2"
   local paths_file=""
 
-  paths_file="$(mktemp "$(get_temp_dir)/repos-paths-XXXXXX")"
+  paths_file="$(umask 077 && mktemp "$(get_temp_dir)/repos-paths-XXXXXX")"
   CLEANUP_FILES+=("$paths_file")
   printf '%s\n' "$paths_list" > "$paths_file"
 
@@ -657,7 +657,7 @@ update_workspace_file() {
 
   # Safely write via a temporary file, then move into place
   local tmp=""
-  tmp="$(mktemp "$(get_temp_dir)/repos-workspace-update-XXXXXX")"
+  tmp="$(umask 077 && mktemp "$(get_temp_dir)/repos-workspace-update-XXXXXX")"
   CLEANUP_FILES+=("$tmp")
 
   local rc=0
@@ -710,7 +710,7 @@ main() {
         else
           # Auto-generate debug file securely
           TEMP_DIR=$(get_temp_dir)
-          DEBUG_FILE=$(mktemp "${TEMP_DIR}/repos-workspace-debug-XXXXXX")
+          DEBUG_FILE=$(umask 077 && mktemp "${TEMP_DIR}/repos-workspace-debug-XXXXXX")
           CLEANUP_FILES+=("$DEBUG_FILE")
         fi
         ;;

--- a/scripts/run-pipeline.sh
+++ b/scripts/run-pipeline.sh
@@ -43,7 +43,7 @@ git() {
   # Wrap git to capture and sanitize stderr to prevent credential leakage
   # from git's own error messages (e.g. "fatal: could not read Password for 'https://token@github.com'")
   local tmp_stderr
-  tmp_stderr="$(mktemp "$(get_temp_dir)/git-stderr-XXXXXX")"
+  tmp_stderr="$(umask 077 && mktemp "$(get_temp_dir)/git-stderr-XXXXXX")"
   CLEANUP_FILES+=("$tmp_stderr")
 
   local rc=0

--- a/scripts/update-branches.sh
+++ b/scripts/update-branches.sh
@@ -21,7 +21,7 @@ git() {
   # Wrap git to capture and sanitize stderr to prevent credential leakage
   # from git's own error messages (e.g. "fatal: could not read Password for 'https://token@github.com'")
   local tmp_stderr
-  tmp_stderr="$(mktemp "$(get_temp_dir)/git-stderr-XXXXXX")"
+  tmp_stderr="$(umask 077 && mktemp "$(get_temp_dir)/git-stderr-XXXXXX")"
   CLEANUP_FILES+=("$tmp_stderr")
 
   local rc=0
@@ -175,7 +175,7 @@ while IFS= read -r line; do
   fi
   
   # Read and process the prebuild file securely
-  TMP_DEST=$(mktemp "$(get_temp_dir)/update-branches-XXXXXX")
+  TMP_DEST=$(umask 077 && mktemp "$(get_temp_dir)/update-branches-XXXXXX")
   CLEANUP_FILES+=("$TMP_DEST")
   if [ "$JSON_TOOL" = "jq" ]; then
     jq 'del(.customizations.codespaces.repositories)' -- "$PREBUILD_FILE" > "$TMP_DEST"

--- a/scripts/update-scripts.sh
+++ b/scripts/update-scripts.sh
@@ -51,7 +51,7 @@ git() {
   # Wrap git to capture and sanitize stderr to prevent credential leakage
   # from git's own error messages (e.g. "fatal: could not read Password for 'https://token@github.com'")
   local tmp_stderr
-  tmp_stderr="$(mktemp "$(get_temp_dir)/git-stderr-XXXXXX")"
+  tmp_stderr="$(umask 077 && mktemp "$(get_temp_dir)/git-stderr-XXXXXX")"
   CLEANUP_FILES+=("$tmp_stderr")
 
   local rc=0
@@ -161,7 +161,7 @@ fi
 
 # --- Create temp directory ---
 # Use mktemp without -- for portability with BSD/macOS
-TEMP_DIR="$(mktemp -d)"
+TEMP_DIR="$(umask 077 && mktemp -d)"
 
 printf 'Fetching scripts from %s (branch: %s)...\n' "$UPSTREAM_REPO" "$UPSTREAM_BRANCH"
 

--- a/tests/test-umask-hardening.sh
+++ b/tests/test-umask-hardening.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# tests/test-umask-hardening.sh
+set -euo pipefail
+
+# This test verifies that temporary files are created with restrictive permissions (0600)
+# regardless of the ambient umask.
+
+# Set a permissive umask
+umask 022
+
+# We want to check if our scripts create temporary files securely.
+# Since mktemp on this system might already be secure, we will
+# primarily check for the presence of the umask 077 hardening pattern
+# in the source code, as mandated by the project's security standards.
+
+echo "Checking scripts for umask 077 protection on mktemp calls..."
+
+# List of scripts that should be hardened
+SCRIPTS=(
+    "scripts/add-branch.sh"
+    "scripts/run-pipeline.sh"
+    "scripts/update-branches.sh"
+    "scripts/update-scripts.sh"
+    "scripts/helper/clone-repos.sh"
+    "scripts/helper/codespaces-auth-add.sh"
+    "scripts/helper/create-repos.sh"
+    "scripts/helper/vscode-workspace-add.sh"
+)
+
+failed=0
+for script in "${SCRIPTS[@]}"; do
+    if [ ! -f "$script" ]; then
+        echo "Warning: $script not found, skipping."
+        continue
+    fi
+
+    # Find mktemp calls that don't have umask 077
+    # We look for lines containing mktemp but NOT umask 077
+    # We ignore comments and documentation strings about requirements
+    insecure_calls=$(grep "mktemp" "$script" | grep -v "umask 077" | grep -v "^#" | grep -v "for cmd in" || true)
+
+    if [ -n "$insecure_calls" ]; then
+        echo "❌ Insecure mktemp call(s) found in $script:"
+        echo "$insecure_calls"
+        failed=1
+    else
+        echo "✅ $script appears hardened."
+    fi
+done
+
+if [ $failed -eq 1 ]; then
+    echo ""
+    echo "VULNERABILITY DEMONSTRATION:"
+    echo "On systems where mktemp respects umask, these files would be created"
+    echo "with permissions like 0644, allowing other users to read sensitive data."
+    echo "Ambient umask is $(umask), which would result in 0644 permissions."
+    exit 1
+else
+    echo "All scripts are hardened with umask 077."
+    exit 0
+fi


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Temporary files (including those containing sensitive git error messages or tokens) were created with the default ambient umask, potentially making them world-readable on some systems.
🎯 Impact: Sensitive data could be leaked to other users on the same system.
🔧 Fix: Wrapped all `mktemp` calls in subshells with `umask 077` to ensure restrictive `0600` or `0700` permissions from the moment of creation.
✅ Verification: Added `tests/test-umask-hardening.sh` which performs static analysis on scripts to ensure the `umask 077 && mktemp` pattern is followed. All security tests passed.

---
*PR created automatically by Jules for task [14277576692829964265](https://jules.google.com/task/14277576692829964265) started by @MiguelRodo*