### PR TITLE
🛡️ Sentinel: [HIGH] Fix insecure chmod on symlinks

### DIFF
--- a/.github/workflows/test-installation.yml
+++ b/.github/workflows/test-installation.yml
@@ -159,6 +159,12 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y git curl jq bash
       
+      - name: Run local installation script
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          export PATH="$HOME/.local/bin:$PATH"
+          bash install-local.sh
+
       - name: Run installer regression test
         run: |
           bash tests/test-install-local-binary.sh
@@ -216,11 +222,6 @@ jobs:
           $installDir = Join-Path $env:USERPROFILE ".local\bin"
           New-Item -ItemType Directory -Path $installDir -Force | Out-Null
           $env:Path = "$installDir;$env:Path"
-          # Mock Invoke-WebRequest to avoid 404 from non-existent release
-          function Invoke-WebRequest {
-            param([string]$Uri, [string]$OutFile)
-            Set-Content -Path $OutFile -Value "mock repos binary"
-          }
           .\install.ps1
           Write-Host "Installation script executed"
       

--- a/.github/workflows/test-installation.yml
+++ b/.github/workflows/test-installation.yml
@@ -159,12 +159,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y git curl jq bash
       
-      - name: Run local installation script
-        run: |
-          mkdir -p "$HOME/.local/bin"
-          export PATH="$HOME/.local/bin:$PATH"
-          bash install-local.sh
-
       - name: Run installer regression test
         run: |
           bash tests/test-install-local-binary.sh
@@ -222,6 +216,11 @@ jobs:
           $installDir = Join-Path $env:USERPROFILE ".local\bin"
           New-Item -ItemType Directory -Path $installDir -Force | Out-Null
           $env:Path = "$installDir;$env:Path"
+          # Mock Invoke-WebRequest to avoid 404 from non-existent release
+          function Invoke-WebRequest {
+            param([string]$Uri, [string]$OutFile)
+            Set-Content -Path $OutFile -Value "mock repos binary"
+          }
           .\install.ps1
           Write-Host "Installation script executed"
       

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - [Insecure Chmod on Symlinks in Go]
+**Vulnerability:** `os.Chmod` in Go follows symbolic links, which can lead to unauthorized permission changes on sensitive files outside the intended scope if an attacker places a symlink in a repository.
+**Learning:** Standard library functions like `os.Chmod` and `os.Stat` follow symlinks by default. In a multi-repo management tool that handles potentially untrusted repository content, this creates a "CWE-59: Improper Link Resolution Before File Operation" vulnerability.
+**Prevention:** Always use `os.Lstat` to inspect a file before calling `os.Chmod`. Verify that the file is a regular file (`info.Mode().IsRegular()`) and NOT a symlink before attempting to change its permissions.

--- a/cmd/repos/run.go
+++ b/cmd/repos/run.go
@@ -412,12 +412,15 @@ func runScriptInTarget(t pipelineTarget, opts runOptions) runScriptResult {
 	}
 
 	scriptPath := filepath.Join(t.target.path, t.script)
-	if _, err := os.Stat(scriptPath); err != nil {
+	sinfo, err := os.Lstat(scriptPath)
+	if err != nil {
 		printPrefixedLine(t.target.name, "SKIP: no "+t.script+" found", nil)
 		return runScriptResult{skipped: true}
 	}
-	if err := os.Chmod(scriptPath, 0o755); err != nil {
-		printPrefixedLine(t.target.name, "Warning: could not chmod "+t.script+": "+err.Error(), nil)
+	if sinfo.Mode().IsRegular() {
+		if err := os.Chmod(scriptPath, 0o755); err != nil {
+			printPrefixedLine(t.target.name, "Warning: could not chmod "+t.script+": "+err.Error(), nil)
+		}
 	}
 
 	cmd := exec.Command("./" + t.script)

--- a/cmd/repos/run_test.go
+++ b/cmd/repos/run_test.go
@@ -325,3 +325,46 @@ func assertFileExists(t *testing.T, path string) {
 		t.Fatalf("expected file %s to exist: %v", path, err)
 	}
 }
+
+func TestRunDoesNotChmodSymlinks(t *testing.T) {
+	tmp := t.TempDir()
+	sensitiveFile := filepath.Join(tmp, "sensitive")
+	if err := os.WriteFile(sensitiveFile, []byte("secret"), 0600); err != nil {
+		t.Fatalf("failed to write sensitive file: %v", err)
+	}
+
+	projectDir := filepath.Join(tmp, "project")
+	repo1 := filepath.Join(tmp, "repo-one")
+	mustMkdirAll(t, projectDir, repo1)
+
+	// Create a symlink named run.sh pointing to the sensitive file
+	scriptPath := filepath.Join(repo1, "run.sh")
+	if err := os.Symlink(sensitiveFile, scriptPath); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+
+	mustWriteFile(t, filepath.Join(projectDir, "repos.list"), "example/repo-one\n")
+
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(oldWD)
+	})
+	if err := os.Chdir(projectDir); err != nil {
+		t.Fatalf("chdir project dir: %v", err)
+	}
+
+	// runRun will attempt to run run.sh in repo-one
+	_ = runRun([]string{"--skip-deps"})
+
+	info, err := os.Stat(sensitiveFile)
+	if err != nil {
+		t.Fatalf("stat sensitive file: %v", err)
+	}
+
+	if info.Mode().Perm() != 0600 {
+		t.Fatalf("VULNERABILITY: sensitive file permissions changed to %o", info.Mode().Perm())
+	}
+}

--- a/internal/sysutil/file.go
+++ b/internal/sysutil/file.go
@@ -112,6 +112,13 @@ func mirrorDir(srcDir, dstDir string, srcPerm os.FileMode, opts MirrorOptions) (
 }
 
 func ensurePerms(path string, mode os.FileMode) error {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", path, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return nil
+	}
 	if err := os.Chmod(path, mode); err != nil {
 		return fmt.Errorf("set permissions on %s: %w", path, err)
 	}
@@ -125,11 +132,14 @@ func mirrorFile(src, dst string, srcPerm os.FileMode) (bool, error) {
 	}
 
 	if same {
-		dstInfo, err := os.Stat(dst)
+		dstInfo, err := os.Lstat(dst)
 		if err != nil {
 			return false, fmt.Errorf("stat destination %s: %w", dst, err)
 		}
 		if dstInfo.Mode().Perm() != srcPerm {
+			if dstInfo.Mode()&os.ModeSymlink != 0 {
+				return false, nil
+			}
 			if err := os.Chmod(dst, srcPerm); err != nil {
 				return false, fmt.Errorf("set permissions on %s: %w", dst, err)
 			}


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix insecure chmod on symlinks

This PR addresses a security vulnerability where the tool could inadvertently follow symbolic links and change permissions of sensitive files on the host system.

### Vulnerability
In Go, `os.Chmod` follows symlinks. If a managed repository contains a symlink named `run.sh` pointing to a sensitive file (e.g., `~/.ssh/id_rsa`), running `repos run` would attempt to make that file executable by calling `os.Chmod(scriptPath, 0755)`, thereby changing the permissions of the sensitive target file.

### Fix
- Modified `cmd/repos/run.go` to use `os.Lstat` instead of `os.Stat` for script detection.
- Added an explicit check `sinfo.Mode().IsRegular()` before calling `os.Chmod`.
- Hardened `internal/sysutil/file.go` by updating `ensurePerms` and `mirrorFile` to avoid calling `os.Chmod` on symlinks.

### Verification
- Added a new regression test `TestRunDoesNotChmodSymlinks` in `cmd/repos/run_test.go` that specifically verifies that `run` does not modify the permissions of a symlink target.
- Verified that all Go tests pass with `go test ./...`.
- Performed a manual reproduction and confirmed the fix.

Severity: HIGH (CWE-59)
Impact: Potential privilege escalation or information exposure by relaxing permissions on sensitive files.
Fix: Secure file handling by checking for symbolic links before permission modifications.

---
*PR created automatically by Jules for task [7789506822489339509](https://jules.google.com/task/7789506822489339509) started by @MiguelRodo*