### PR TITLE
🛡️ Sentinel: [HIGH] Prevent os.Chmod from following symlinks

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-23 - [Symlink Following in os.Chmod]
+**Vulnerability:** os.Chmod and os.Stat follow symbolic links by default in Go. An attacker could place a symlink at a location the application expects to modify, causing the application to change permissions on an unintended target file (e.g., a sensitive system file).
+**Learning:** Go's os.Chmod follows symlinks on many platforms. If the path is controllable or replaceable by an attacker, this leads to privilege escalation or unauthorized file access.
+**Prevention:** Always use os.Lstat to verify that a path is a regular file or directory before calling os.Chmod. Ensure that any prior checks on the file also used Lstat to avoid inconsistencies.

--- a/cmd/repos/run.go
+++ b/cmd/repos/run.go
@@ -467,8 +467,12 @@ func runScriptInTarget(t pipelineTarget, opts runOptions) runScriptResult {
 		printPrefixedLine(t.target.name, "SKIP: no "+t.script+" found", nil)
 		return runScriptResult{skipped: true}
 	}
-	if err := os.Chmod(scriptPath, 0o755); err != nil {
-		printPrefixedLine(t.target.name, "Warning: could not chmod "+t.script+": "+err.Error(), nil)
+	// Security: Use Lstat to ensure we don't follow symlinks when calling Chmod.
+	// os.Chmod follows symlinks on many platforms, which could lead to privilege escalation.
+	if info, err := os.Lstat(scriptPath); err == nil && info.Mode().IsRegular() {
+		if err := os.Chmod(scriptPath, 0o755); err != nil {
+			printPrefixedLine(t.target.name, "Warning: could not chmod "+t.script+": "+err.Error(), nil)
+		}
 	}
 
 	cmd := commandForScript(t.script)

--- a/internal/sysutil/file.go
+++ b/internal/sysutil/file.go
@@ -65,10 +65,13 @@ func mirrorDir(srcDir, dstDir string, srcPerm os.FileMode, opts MirrorOptions) (
 			}
 			changed = true
 		} else if dstInfo.Mode().Perm() != srcPerm {
-			if err := os.Chmod(dstDir, srcPerm); err != nil {
-				return false, fmt.Errorf("set permissions on %s: %w", dstDir, err)
+			// Security: ensure we don't follow symlinks when calling Chmod.
+			if dstInfo.Mode().IsRegular() || dstInfo.IsDir() {
+				if err := os.Chmod(dstDir, srcPerm); err != nil {
+					return false, fmt.Errorf("set permissions on %s: %w", dstDir, err)
+				}
+				changed = true
 			}
-			changed = true
 		}
 	}
 
@@ -112,8 +115,15 @@ func mirrorDir(srcDir, dstDir string, srcPerm os.FileMode, opts MirrorOptions) (
 }
 
 func ensurePerms(path string, mode os.FileMode) error {
-	if err := os.Chmod(path, mode); err != nil {
-		return fmt.Errorf("set permissions on %s: %w", path, err)
+	// Security: ensure we don't follow symlinks when calling Chmod.
+	info, err := os.Lstat(path)
+	if err != nil {
+		return fmt.Errorf("stat %s: %w", path, err)
+	}
+	if info.Mode().IsRegular() || info.IsDir() {
+		if err := os.Chmod(path, mode); err != nil {
+			return fmt.Errorf("set permissions on %s: %w", path, err)
+		}
 	}
 	return nil
 }
@@ -125,15 +135,19 @@ func mirrorFile(src, dst string, srcPerm os.FileMode) (bool, error) {
 	}
 
 	if same {
-		dstInfo, err := os.Stat(dst)
+		dstInfo, err := os.Lstat(dst)
 		if err != nil {
 			return false, fmt.Errorf("stat destination %s: %w", dst, err)
 		}
 		if dstInfo.Mode().Perm() != srcPerm {
-			if err := os.Chmod(dst, srcPerm); err != nil {
-				return false, fmt.Errorf("set permissions on %s: %w", dst, err)
+			// Security: ensure we don't follow symlinks when calling Chmod.
+			if dstInfo.Mode().IsRegular() || dstInfo.IsDir() {
+				if err := os.Chmod(dst, srcPerm); err != nil {
+					return false, fmt.Errorf("set permissions on %s: %w", dst, err)
+				}
+				return true, nil
 			}
-			return true, nil
+			return false, nil
 		}
 		return false, nil
 	}


### PR DESCRIPTION
This PR addresses a security vulnerability where the `repos` tool followed symbolic links when changing file permissions using `os.Chmod`. 

🚨 **Severity: HIGH**
💡 **Vulnerability:** Symbolic link following in `os.Chmod`.
🎯 **Impact:** An attacker could trick the tool into changing permissions of arbitrary files on the system if they can control the contents of a repository or the `repos.list` file.
🔧 **Fix:** Added `os.Lstat` checks before all `os.Chmod` calls to ensure only regular files and directories are affected.
✅ **Verification:** A reproduction script confirmed that `os.Chmod` followed a symlink to change a sensitive file's permissions before the fix, and stopped doing so after the fix. All unit tests pass.

---
*PR created automatically by Jules for task [7162983011569528509](https://jules.google.com/task/7162983011569528509) started by @MiguelRodo*