### PR TITLE
🛡️ Sentinel: Fix incomplete URL sanitization for credentials with @

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-15 - Credential Leakage via Incomplete URL Sanitization
+**Vulnerability:** Incomplete sanitization of Git credentials in URLs. The previous regex `(https?://)[^/@\s]+@` stopped at the first `@` character encountered in the credential portion of the URL. If a password or token contained an `@`, the portion after the first `@` would remain in the output, potentially leaking sensitive credentials in logs or error messages.
+**Learning:** Sanitization regexes for URLs must be greedy up to the *last* `@` before the host/path begins to handle cases where credentials themselves contain the separator character.
+**Prevention:** Use a more inclusive negated character class like `[^/\s]+@` to capture everything from the protocol scheme until the final `@` before the URL path starts.

--- a/internal/gitcmd/exec.go
+++ b/internal/gitcmd/exec.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-var sanitizeURLRegex = regexp.MustCompile(`(https?://)[^/@\s]+@`)
+var sanitizeURLRegex = regexp.MustCompile(`(https?://)[^/\s]+@`)
 
 func RunGit(dir string, args ...string) (string, error) {
 	cmd := exec.Command("git", args...)

--- a/internal/gitcmd/exec_test.go
+++ b/internal/gitcmd/exec_test.go
@@ -1,0 +1,46 @@
+package gitcmd
+
+import "testing"
+
+func TestSanitizeURL(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "plain URL",
+			in:   "https://github.com/path",
+			want: "https://github.com/path",
+		},
+		{
+			name: "simple credentials",
+			in:   "https://user:password@github.com/path",
+			want: "https://github.com/path",
+		},
+		{
+			name: "multiple @ in credentials",
+			in:   "https://user:p@ss@github.com/path",
+			want: "https://github.com/path",
+		},
+		{
+			name: "token in credentials",
+			in:   "https://ghp_abcdef@github.com/path",
+			want: "https://github.com/path",
+		},
+		{
+			name: "non-http string",
+			in:   "git clone https://user:password@github.com/path",
+			want: "git clone https://github.com/path",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SanitizeURL(tt.in)
+			if got != tt.want {
+				t.Errorf("SanitizeURL(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
🛡️ **Sentinel: Security Fix - Incomplete URL Sanitization**

🚨 **Severity:** MEDIUM
💡 **Vulnerability:** The URL sanitization logic in `internal/gitcmd/exec.go` used a non-greedy regex that failed to fully strip credentials if the password or token contained an `@` character.
🎯 **Impact:** Sensitive credentials (like GitHub tokens) could be partially leaked in terminal output, debug logs, or error messages.
🔧 **Fix:** Updated `sanitizeURLRegex` to be greedy by removing `@` from the negated character class. It now correctly identifies and strips the entire credential block.
✅ **Verification:** 
- Added a new unit test suite in `internal/gitcmd/exec_test.go` covering various credential formats.
- Verified the fix with `go test ./internal/gitcmd/...`.
- Ensured no regressions by running the full Go test suite.
- Documented the finding in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [10284040312995711583](https://jules.google.com/task/10284040312995711583) started by @MiguelRodo*