### PR TITLE
feat: Add version flag to CLI

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,6 +3,8 @@ project_name: repos
 builds:
   - id: repos-linux
     main: ./cmd/repos
+    ldflags:
+      - -s -w -X main.version={{.Version}}
     goos:
       - linux
     goarch:
@@ -10,6 +12,8 @@ builds:
       - arm64
   - id: repos-darwin
     main: ./cmd/repos
+    ldflags:
+      - -s -w -X main.version={{.Version}}
     goos:
       - darwin
     goarch:
@@ -17,6 +21,8 @@ builds:
       - arm64
   - id: repos-windows
     main: ./cmd/repos
+    ldflags:
+      - -s -w -X main.version={{.Version}}
     goos:
       - windows
     goarch:

--- a/cmd/repos/main.go
+++ b/cmd/repos/main.go
@@ -68,6 +68,8 @@ type instruction struct {
 	depth       int
 }
 
+var version = "dev"
+
 var ownerRepoRegex = regexp.MustCompile(`^[^/]+/[^/]+$`)
 
 const (
@@ -116,6 +118,9 @@ func main() {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
+	case "version", "--version", "-v":
+		fmt.Printf("repos version %s\n", version)
+		os.Exit(0)
 	case "-h", "--help", "help":
 		usage()
 	default:
@@ -135,6 +140,7 @@ Commands:
   codespace         Set GH_TOKEN Codespaces secrets for managed repositories
   run               Execute a command inside each repository from repos.list
   create            Create missing GitHub repositories from repos.list
+  version           Print the version number
 
 Run 'repos <command> --help' for more information.
 `)


### PR DESCRIPTION
This commit adds the `version` variable to `cmd/repos/main.go` and handles the `version`, `--version`, and `-v` commands to display the CLI's version. It also updates `.goreleaser.yml` to inject the version string into the Go binary during build time.

---
*PR created automatically by Jules for task [4667539330016687727](https://jules.google.com/task/4667539330016687727) started by @MiguelRodo*