### PR TITLE
Remove fetch_mode shim in repos_clone

### DIFF
--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -284,16 +284,6 @@ repos_clone <- function(file = NULL, worktree = FALSE, debug = FALSE,
                         depth = NULL, ...) {
   args <- character()
 
-  # Backward compatibility for positional calls introduced while fetch_mode
-  # was temporarily the 3rd argument.
-  # TODO: remove this shim in the next major release.
-  # repos_clone(file, worktree, "single")
-  if (is.null(fetch_mode) && is.character(debug) && length(debug) == 1 &&
-      debug %in% c("deferred", "single", "all")) {
-    fetch_mode <- debug
-    debug <- FALSE
-  }
-
   if (!is.null(file)) {
     args <- c(args, "-f", file)
   }


### PR DESCRIPTION
Removed the backwards-compatibility shim in `R/wrappers.R` for `repos_clone` which handled legacy positional argument ordering where `fetch_mode` was temporarily passed as the third parameter.

Fixes an explicit `TODO` item requesting the removal in the next major release. Tested with the `Rscript tests/test-r-wrappers.R` command to ensure tests continue to pass correctly without issue.

---
*PR created automatically by Jules for task [10129529388135374271](https://jules.google.com/task/10129529388135374271) started by @MiguelRodo*