### PR TITLE
🧪 [test] add exception handling test for installed_cli_version

### DIFF
--- a/tests/test-python-wrappers.py
+++ b/tests/test-python-wrappers.py
@@ -219,6 +219,32 @@ def test_run_backward_compat():
     assert "test.sh" in test_args["args"]
     assert "--dry-run" in test_args["args"]
 
+def test_installed_cli_version_exception():
+    import shutil
+    import subprocess
+
+    # Save original functions
+    orig_which = shutil.which
+    orig_run = subprocess.run
+
+    try:
+        # Mock shutil.which to pretend CLI is installed
+        shutil.which = lambda x: "/usr/local/bin/repos" if x == "repos" else orig_which(x)
+
+        # Mock subprocess.run to raise an exception
+        def mock_subprocess_run(*args, **kwargs):
+            raise Exception("Mocked subprocess exception")
+
+        subprocess.run = mock_subprocess_run
+
+        # Test the function
+        result = repos.installed_cli_version()
+        assert result is None, f"Expected None, got {result}"
+    finally:
+        # Restore original functions
+        shutil.which = orig_which
+        subprocess.run = orig_run
+
 # Run all tests
 if __name__ == "__main__":
     print("Testing Python wrapper functions\n")
@@ -251,6 +277,7 @@ if __name__ == "__main__":
     test("repos.run(continue_on_error=True)", test_run_continue_on_error)
     test("repos.run(file='custom.list')", test_run_file)
     test("repos.run_raw('--script', 'test.sh', '--dry-run') backward compatibility", test_run_backward_compat)
+    test("repos.installed_cli_version() handles subprocess Exception", test_installed_cli_version_exception)
     
     print("\n" + "=" * 40)
     print(f"Total tests: {test_count}")


### PR DESCRIPTION
🎯 **What:** The `installed_cli_version()` function in `src/repos/__init__.py` relies on a `try/except Exception` block wrapped around `subprocess.run` to safely handle runtime execution errors. However, this exception handling path lacked test coverage.
  📊 **Coverage:** Added the `test_installed_cli_version_exception` function to `tests/test-python-wrappers.py`. This test mocks both `shutil.which` (to simulate the CLI being present) and `subprocess.run` (to raise a generic `Exception`), successfully asserting that the helper returns `None` as intended.
  ✨ **Result:** The `installed_cli_version` function is now fully covered, improving the confidence that unexpected CLI runtime errors are correctly caught and handled without crashing the host Python process.

---
*PR created automatically by Jules for task [6287282314264727441](https://jules.google.com/task/6287282314264727441) started by @MiguelRodo*