### PR TITLE
Refactor `repos codespace` to remove GitHub token requirement

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,6 @@ When modifying or extending the tool:
 |---|---|
 | CLI Application | **Go** (`cmd/repos/`) |
 | VCS | **Git** (including `git worktree`) |
-| GitHub auth | `GH_TOKEN` env var or `gh` CLI |
 
 ### Wrappers
 | Language | Entry point |

--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -409,7 +409,7 @@ repos_workspace <- function(file = NULL, debug = FALSE, debug_file = NULL, ...) 
 
 #' Configure GitHub Codespaces Authentication
 #'
-#' Inject the \code{GH_TOKEN} Codespaces secret into every cloned repository
+#' Update devcontainer.json with codespaces permissions for managed repositories
 #' that has a \code{devcontainer.json}.
 #'
 #' @param file Path to repos list file (default: repos.list)

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Hugging Face entries (`hf:...`) require `huggingface-cli`
 - `repos workspace` — generate or refresh `entire-project.code-workspace`
 - `repos run` — run scripts or explicit commands across managed repos
 - `repos create` — create missing GitHub repos from `repos.list`
-- `repos codespace` — configure `GH_TOKEN` Codespaces secrets and devcontainer
+- `repos codespace` — configure devcontainer
   repository permissions
 - `repos install-r-deps` — install R dependencies across managed repos
 

--- a/cmd/repos/codespaces_auth.go
+++ b/cmd/repos/codespaces_auth.go
@@ -10,14 +10,15 @@ import (
 	"io/fs"
 	"net/url"
 	"os"
-	"os/exec"
+
 	"path/filepath"
 	"sort"
 	"strings"
 
+
 	"github.com/MiguelRodo/repos/v2/internal/gitcmd"
 	"github.com/MiguelRodo/repos/v2/internal/parser"
-	"golang.org/x/term"
+
 )
 
 // stringSliceFlag is a flag.Value that accumulates multiple --flag values into a slice.
@@ -59,7 +60,7 @@ func runCodespacesAuth(args []string) error {
 	cfs.Var(&devcontainerPaths, "d", "path relative to .devcontainer/ to update (shorthand for --devcontainer)")
 	allDevcontainers := cfs.Bool("all", false, "update all devcontainer.json files under .devcontainer/")
 	permissions := cfs.String("permissions", "default", `permissions level for repositories block: "default", "all", or "contents"`)
-	dryRun := cfs.Bool("dry-run", false, "print devcontainer.json changes to stdout without writing; also skips setting GH_TOKEN secret")
+	dryRun := cfs.Bool("dry-run", false, "print devcontainer.json changes to stdout without writing")
 	cfs.BoolVar(dryRun, "n", false, "same as --dry-run")
 
 	// Debug flags
@@ -108,15 +109,7 @@ func runCodespacesAuth(args []string) error {
 		fmt.Fprintf(w, "[DEBUG codespaces-go] "+format+"\n", a...)
 	}
 
-	if _, err := exec.LookPath("gh"); err != nil {
-		return errors.New("gh CLI is required but was not found on PATH")
-	}
-
-	token, err := resolveCodespacesToken()
-	if err != nil {
-		return err
-	}
-
+	// Determine devcontainer.json paths to update.
 	absReposFile, err := filepath.Abs(*reposFile)
 	if err != nil {
 		return fmt.Errorf("resolving repos file path: %w", err)
@@ -128,29 +121,6 @@ func runCodespacesAuth(args []string) error {
 	}
 	dbg("found %d managed repositories", len(repos))
 
-	// Set GH_TOKEN Codespaces secret for each repository.
-	if *dryRun {
-		fmt.Printf("DRY-RUN: would set GH_TOKEN Codespaces secret for %d repositories:\n", len(repos))
-		for _, repo := range repos {
-			fmt.Printf("  - %s\n", repo)
-		}
-	} else {
-		repoWord := "repositories"
-		if len(repos) == 1 {
-			repoWord = "repository"
-		}
-		fmt.Printf("Setting GH_TOKEN secret for %d %s...\n", len(repos), repoWord)
-		for _, repo := range repos {
-			fmt.Printf("  - %s\n", repo)
-			dbg("setting GH_TOKEN secret for %s", repo)
-			if err := setRepoCodespacesSecret(repo, token); err != nil {
-				return err
-			}
-		}
-		fmt.Println("Done.")
-	}
-
-	// Determine devcontainer.json paths to update.
 	var dcPaths []string
 	if *allDevcontainers {
 		dbg("scanning .devcontainer/ for all devcontainer.json files")
@@ -190,13 +160,8 @@ func codespacesAuthUsage() {
                         [--permissions default|all|contents] [--dry-run]
                         [--debug] [--debug-file [file]]
 
-Sets the GH_TOKEN Codespaces secret for each managed repository and updates
-devcontainer.json with the customizations.codespaces.repositories block.
-
-Token lookup order:
-  1) GH_TOKEN
-  2) CODESPACES_TOKEN
-  3) Secure terminal prompt
+Updates devcontainer.json with the customizations.codespaces.repositories block
+for each managed repository.
 
 Options:
   -f, --file <file>           Path to repo list file (default: repos.list,
@@ -212,40 +177,12 @@ Options:
                                 all      - write-all
                                 contents - contents write only
   -n, --dry-run               Print devcontainer.json changes to stdout without
-                              writing; also skips setting GH_TOKEN secret
+                              writing
   --debug                     Enable debug output to stderr.
   --debug-file [file]         Enable debug output to file (auto-generate temp
                               if no path given).
   -h, --help                  Show this help message.
 `)
-}
-
-func resolveCodespacesToken() (string, error) {
-	if tok := strings.TrimSpace(os.Getenv("GH_TOKEN")); tok != "" {
-		return tok, nil
-	}
-	if tok := strings.TrimSpace(os.Getenv("CODESPACES_TOKEN")); tok != "" {
-		return tok, nil
-	}
-	return promptTokenSecurely()
-}
-
-func promptTokenSecurely() (string, error) {
-	if !term.IsTerminal(int(os.Stdin.Fd())) {
-		return "", errors.New("no GH_TOKEN or CODESPACES_TOKEN set and stdin is not interactive")
-	}
-
-	fmt.Fprint(os.Stderr, "Enter token to store as GH_TOKEN secret: ")
-	line, err := term.ReadPassword(int(os.Stdin.Fd()))
-	fmt.Fprintln(os.Stderr)
-	if err != nil {
-		return "", fmt.Errorf("reading token: %w", err)
-	}
-	token := strings.TrimSpace(string(line))
-	if token == "" {
-		return "", errors.New("token cannot be empty")
-	}
-	return token, nil
 }
 
 func parseManagedReposFromFile(path string) ([]string, error) {
@@ -323,20 +260,6 @@ func parseManagedRepos(r io.Reader, resolveFallbackRemote func() (string, error)
 	}
 	sort.Strings(repos)
 	return repos, nil
-}
-
-func setRepoCodespacesSecret(repo, token string) error {
-	cmd := exec.Command("gh", "secret", "set", "GH_TOKEN", "--repo", repo, "--app", "codespaces")
-	cmd.Stdin = strings.NewReader(token)
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		msg := strings.TrimSpace(string(out))
-		if msg == "" {
-			return fmt.Errorf("failed setting GH_TOKEN secret for %s: %w", repo, err)
-		}
-		return fmt.Errorf("failed setting GH_TOKEN secret for %s: %s", repo, gitcmd.SanitizeURL(msg))
-	}
-	return nil
 }
 
 func hasPathTraversal(spec string) bool {

--- a/cmd/repos/main.go
+++ b/cmd/repos/main.go
@@ -137,7 +137,7 @@ Commands:
   clone             Clone repositories listed in repos.list into the parent directory
   workspace         Manage VS Code .code-workspace files
   install-r-deps    Install R dependencies for managed repositories
-  codespace         Set GH_TOKEN Codespaces secrets for managed repositories
+  codespace         Update devcontainer.json with codespaces permissions for managed repositories
   run               Execute a command inside each repository from repos.list
   create            Create missing GitHub repositories from repos.list
   version           Print the version number

--- a/index.qmd
+++ b/index.qmd
@@ -44,7 +44,7 @@ clone plus immediate wildcard fetch-refspec restoration. You can also use
 - `repos workspace` — generate or refresh `entire-project.code-workspace`
 - `repos run` — run scripts or explicit commands across managed repos
 - `repos create` — create missing GitHub repos from `repos.list`
-- `repos codespace` — configure `GH_TOKEN` Codespaces secrets and devcontainer
+- `repos codespace` — configure devcontainer
   repository permissions
 - `repos install-r-deps` — install R dependencies across managed repos
 

--- a/install.qmd
+++ b/install.qmd
@@ -97,8 +97,6 @@ sudo dpkg -r repos
 - Required only for specific commands:
   - `repos create`: `gh` CLI with authentication (`gh auth login` or
     `GH_TOKEN`)
-  - `repos codespace`: token via `GH_TOKEN` (or `CODESPACES_TOKEN`) and `gh`
-    available on `PATH`
   - `Rscript` (`repos install-r-deps`)
 
 ---
@@ -175,7 +173,7 @@ install.packages("devtools")
 devtools::install_github("MiguelRodo/repos")
 ```
 
-Requires `repos`, `git`, and `gh` on your system `PATH` for full wrapper
+Requires `repos` and `git` on your system `PATH` for full wrapper
 coverage (including Codespaces helpers).
 
 ### Python Package
@@ -192,7 +190,7 @@ cd repos
 pip install .
 ```
 
-Requires `repos`, `git`, and `gh` on your system `PATH` for full wrapper
+Requires `repos` and `git` on your system `PATH` for full wrapper
 coverage (including Codespaces helpers).
 
 ---

--- a/man/repos_codespace.Rd
+++ b/man/repos_codespace.Rd
@@ -36,7 +36,7 @@ repos_codespace(
 Invisibly returns the exit status of the script (0 for success).
 }
 \description{
-Inject the \code{GH_TOKEN} Codespaces secret into every cloned repository
+Update devcontainer.json with codespaces permissions for managed repositories
 that has a \code{devcontainer.json}.
 }
 \details{

--- a/python-package.qmd
+++ b/python-package.qmd
@@ -21,7 +21,6 @@ pip install .
 ```
 
 **System requirements:** `repos` and `git` must be available on your `PATH`.
-For Codespaces support (`codespace()`), `gh` must also be available.
 
 ## End-to-End Workflow
 
@@ -219,7 +218,7 @@ For the full description, see the [VS Code integration guide](vscode.html).
 
 ### `codespace()` {#codespace}
 
-Configure GitHub Codespaces authentication.
+Configure GitHub Codespaces devcontainer.json.
 
 ```python
 from repos import codespace
@@ -354,26 +353,6 @@ run_raw("-f", "custom.list", "--continue-on-error")
 
 These functions forward all positional arguments directly to the corresponding
 `repos` subcommand.
-
-## GitHub Authentication
-
-`codespace()` needs a GitHub token with Codespaces permissions.
-Provide it via the `GH_TOKEN` environment variable or via the `gh` CLI:
-
-```python
-import os, subprocess
-from repos import codespace
-
-os.environ["GH_TOKEN"] = "your_personal_access_token"
-codespace()
-```
-
-Or in a shell before starting Python:
-
-```bash
-export GH_TOKEN="your_personal_access_token"
-python my_script.py
-```
 
 ## Target CLI version vs. installed CLI
 

--- a/r-package.qmd
+++ b/r-package.qmd
@@ -14,7 +14,6 @@ devtools::install_github("MiguelRodo/repos")
 ```
 
 **System requirements:** `repos` and `git` must be available on your `PATH`.
-For Codespaces support (`repos_codespace()`), `gh` must also be available.
 
 ## End-to-End Workflow
 
@@ -239,7 +238,7 @@ For the full description, see the [VS Code integration guide](vscode.html).
 
 ### `repos_codespace()` {#repos_codespace}
 
-Configure GitHub Codespaces authentication.
+Configure GitHub Codespaces devcontainer.json.
 
 ```r
 repos_codespace(
@@ -357,22 +356,6 @@ repos_run("--script", "build.sh", "--dry-run")
 ```
 
 For the full description, see [Running Pipelines](pipelines.html).
-
-## GitHub Authentication
-
-`repos_codespace()` needs a GitHub token with Codespaces permissions.
-Provide it via the `GH_TOKEN` environment variable or via the `gh` CLI:
-
-```r
-Sys.setenv(GH_TOKEN = "your_personal_access_token")
-repos_codespace()
-```
-
-Or set it in your shell before starting R:
-
-```bash
-export GH_TOKEN="your_personal_access_token"
-```
 
 ## Target CLI version vs. installed CLI
 

--- a/src/repos/__init__.py
+++ b/src/repos/__init__.py
@@ -236,7 +236,7 @@ def codespace(
     """
     Configure GitHub Codespaces authentication.
 
-    Injects the GH_TOKEN Codespaces secret into every cloned repository
+    Updates devcontainer.json with codespaces permissions for managed repositories
     that has a devcontainer.json.
 
     Args:

--- a/vscode.qmd
+++ b/vscode.qmd
@@ -54,10 +54,7 @@ workspace/
 
 ## `repos codespace`
 
-Set the repository-level Codespaces secret named `GH_TOKEN` for each managed
-GitHub repository (via `gh secret set --app codespaces`) and update matching
-`devcontainer.json` files by writing repository permission entries under
-`customizations.codespaces.repositories`.
+Update matching `devcontainer.json` files by writing repository permission entries under `customizations.codespaces.repositories`.
 
 ```bash
 repos codespace
@@ -71,7 +68,7 @@ repos codespace
 | `-d <path>` | Path relative to `.devcontainer/` (repeatable) |
 | `--all` | Update all `devcontainer.json` files found under `.devcontainer/` |
 | `--permissions <level>` | Codespaces permission level (`default`, `all`, or `contents`) |
-| `--dry-run` | Preview secret/file updates without writing changes |
+| `--dry-run` | Preview file updates without writing changes |
 
 Permission levels:
 
@@ -92,18 +89,8 @@ repos codespace -d path1/devcontainer.json -d path2/devcontainer.json
 # Update all devcontainer files under .devcontainer/
 repos codespace --all
 
-# Preview without changing files or secrets
+# Preview without changing files
 repos codespace --dry-run
-```
-
-### GitHub Authentication
-
-`repos codespace` requires a GitHub token with Codespaces permissions:
-
-```bash
-export GH_TOKEN="your_personal_access_token"
-# or
-gh auth login
 ```
 
 ---


### PR DESCRIPTION
Removed GitHub token logic from `repos codespace`.

The user reported that `repos codespace` should just edit the `devcontainer.json` file rather than requesting a token to set GitHub secrets.
This change eliminates the token resolution logic, prompting, and dependency on the `gh` CLI in `codespaces_auth.go`. The tool now solely iterates over the repositories and modifies `devcontainer.json`.
Documentation for R, Python, and the CLI website has been rigorously pruned to remove references to `GH_TOKEN` or Codespaces tokens for this specific command.

---
*PR created automatically by Jules for task [7334266188406261190](https://jules.google.com/task/7334266188406261190) started by @MiguelRodo*