### PR TITLE
docs: add curl and gpg prerequisites to APT installation instructions

### DIFF
--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -88,6 +88,7 @@ repos_install_cli <- function(run = FALSE) {
   if (sysname == "Linux") {
     message("To install the repos CLI on Ubuntu/Debian, choose one of:\n")
     message("  # Option 1: APT repository (recommended -- keeps repos up to date):")
+    message("  sudo apt-get install -y curl gpg")
     message("  curl -fsSL https://miguelrodo.github.io/apt-miguelrodo/KEY.gpg \\")
     message("     | sudo gpg --dearmor -o /usr/share/keyrings/apt-miguelrodo.gpg")
     message('  echo "deb [signed-by=/usr/share/keyrings/apt-miguelrodo.gpg] https://miguelrodo.github.io/apt-miguelrodo stable main" \\')

--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ Install on Linux, macOS, or Windows, with optional R and Python wrappers.
 Common install paths:
 
 ```bash
+# Ubuntu / Debian
+sudo apt-get install -y curl gpg
+curl -fsSL https://miguelrodo.github.io/apt-miguelrodo/KEY.gpg | sudo gpg --dearmor -o /usr/share/keyrings/apt-miguelrodo.gpg
+echo "deb [signed-by=/usr/share/keyrings/apt-miguelrodo.gpg] https://miguelrodo.github.io/apt-miguelrodo stable main" | sudo tee /etc/apt/sources.list.d/apt-miguelrodo.list >/dev/null
+sudo apt-get update && sudo apt-get install -y repos
+
 # Go (from source)
 go install github.com/MiguelRodo/repos/v2/cmd/repos@latest
 ```

--- a/install.qmd
+++ b/install.qmd
@@ -29,6 +29,9 @@ Install the wrapper package (`pip`/`R`) and ensure `repos` is installed on `PATH
 Install and keep `repos` up to date directly via `apt`:
 
 ```bash
+# Install prerequisites
+sudo apt-get install -y curl gpg
+
 # Add repository signing key
 curl -fsSL https://miguelrodo.github.io/apt-miguelrodo/KEY.gpg \
    | sudo gpg --dearmor -o /usr/share/keyrings/apt-miguelrodo.gpg

--- a/src/repos/__init__.py
+++ b/src/repos/__init__.py
@@ -101,6 +101,7 @@ def install_cli(run: bool = False) -> None:
     if system == "Linux":
         print("To install the repos CLI on Ubuntu/Debian, choose one of:\n")
         print("  # Option 1: APT repository (recommended — keeps repos up to date):")
+        print("  sudo apt-get install -y curl gpg")
         print("  curl -fsSL https://miguelrodo.github.io/apt-miguelrodo/KEY.gpg \\")
         print("     | sudo gpg --dearmor -o /usr/share/keyrings/apt-miguelrodo.gpg")
         print('  echo "deb [signed-by=/usr/share/keyrings/apt-miguelrodo.gpg] '


### PR DESCRIPTION
Fixes an issue where users encountered an "unsigned error" when following the `apt-miguelrodo` installation instructions. This occurs when `gpg` is missing on a minimal system, causing the key dearmoring step to silently fail. 

Added the prerequisite command `sudo apt-get install -y curl gpg` to:
- `README.md`
- `install.qmd`
- Python wrapper CLI installation fallback (`src/repos/__init__.py`)
- R wrapper CLI installation fallback (`R/wrappers.R`)

---
*PR created automatically by Jules for task [10632949324629802363](https://jules.google.com/task/10632949324629802363) started by @MiguelRodo*