### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Credential Leakage in normaliseRemoteToHTTPS

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -13,6 +13,8 @@ import (
 	"sync"
 )
 
+var sanitizeURLRegex = regexp.MustCompile(`(https?://)[^/\s]+@`)
+
 type Options struct {
 	InitialFallbackRemote string
 	InitialBaseDir        string
@@ -445,14 +447,7 @@ func normaliseRemoteToHTTPS(url string) string {
 	}
 	u = strings.ReplaceAll(u, "\\", "/")
 	if strings.HasPrefix(u, "http://") || strings.HasPrefix(u, "https://") {
-		if i := strings.Index(u, "://"); i >= 0 {
-			prefix := u[:i+3]
-			rest := u[i+3:]
-			if at := strings.Index(rest, "@"); at >= 0 {
-				rest = rest[at+1:]
-			}
-			u = prefix + rest
-		}
+		u = sanitizeURLRegex.ReplaceAllString(u, "$1")
 		return strings.TrimSuffix(u, "/")
 	}
 	if strings.HasPrefix(u, "ssh://git@") {

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -276,3 +276,41 @@ func TestSpecToHTTPSNormalizesHuggingFaceSlashes(t *testing.T) {
 		}
 	}
 }
+
+func TestNormaliseRemoteToHTTPS(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "plain URL",
+			in:   "https://github.com/path",
+			want: "https://github.com/path",
+		},
+		{
+			name: "simple credentials",
+			in:   "https://user:password@github.com/path",
+			want: "https://github.com/path",
+		},
+		{
+			name: "multiple @ in credentials",
+			in:   "https://user:p@ss@github.com/path",
+			want: "https://github.com/path",
+		},
+		{
+			name: "token in credentials",
+			in:   "https://ghp_abcdef@github.com/path",
+			want: "https://github.com/path",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NormaliseRemoteToHTTPS(tt.in)
+			if got != tt.want {
+				t.Errorf("NormaliseRemoteToHTTPS(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix Credential Leakage in normaliseRemoteToHTTPS

🚨 Severity: CRITICAL
💡 Vulnerability: The `normaliseRemoteToHTTPS` function (in `internal/parser/parser.go`) split credentials strings using the first `@` occurrence. If the credential (password or access token) contained an `@`, the rightmost part would leak into logs or error messages.
🎯 Impact: Passwords, tokens or API keys containing `@` would be leaked if an error occurred during CLI setup or command execution.
🔧 Fix: Updated the function to use the same greedy regex `(https?://)[^/\s]+@` previously added to `internal/gitcmd` for URL sanitization.
✅ Verification: Ran Go tests, explicitly ensuring `TestNormaliseRemoteToHTTPS` handles tokens with multiple `@` symbols successfully.

---
*PR created automatically by Jules for task [14512226895626721355](https://jules.google.com/task/14512226895626721355) started by @MiguelRodo*