### PR TITLE
🧹 Remove backward compatibility shim from repos_clone

### DIFF
--- a/R/wrappers.R
+++ b/R/wrappers.R
@@ -281,16 +281,6 @@ repos_clone <- function(file = NULL, worktree = FALSE, debug = FALSE,
                         debug_file = NULL, fetch_mode = NULL, ...) {
   args <- character()
 
-  # Backward compatibility for positional calls introduced while fetch_mode
-  # was temporarily the 3rd argument.
-  # TODO: remove this shim in the next major release.
-  # repos_clone(file, worktree, "single")
-  if (is.null(fetch_mode) && is.character(debug) && length(debug) == 1 &&
-      debug %in% c("deferred", "single", "all")) {
-    fetch_mode <- debug
-    debug <- FALSE
-  }
-
   if (!is.null(file)) {
     args <- c(args, "-f", file)
   }


### PR DESCRIPTION
Removed the deprecated backward compatibility shim in R/wrappers.R:repos_clone.
The shim was used to handle cases where fetch_mode was temporarily the 3rd
argument. It is no longer needed.
Verified with integration tests and code review.

---
*PR created automatically by Jules for task [5509538169475291864](https://jules.google.com/task/5509538169475291864) started by @MiguelRodo*