### PR TITLE
fix(codespace): preserve devcontainer.json key order

### DIFF
--- a/cmd/repos/codespaces_auth.go
+++ b/cmd/repos/codespaces_auth.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -417,57 +418,70 @@ func stripJSONC(data []byte) []byte {
 }
 
 // buildRepoPermissionsBlock constructs the JSON object for the repositories block.
-func buildRepoPermissionsBlock(repos []string, permissions string) map[string]interface{} {
-	block := make(map[string]interface{}, len(repos))
+func buildRepoPermissionsBlock(repos []string, permissions string) *OrderedMap {
+	block := NewOrderedMap()
 	for _, repo := range repos {
+		repoPerms := NewOrderedMap()
 		switch permissions {
 		case "all":
-			block[repo] = map[string]interface{}{
-				"permissions": "write-all",
-			}
+			repoPerms.Set("permissions", "write-all")
 		case "contents":
-			block[repo] = map[string]interface{}{
-				"permissions": map[string]interface{}{
-					"contents": "write",
-				},
-			}
+			perms := NewOrderedMap()
+			perms.Set("contents", "write")
+			repoPerms.Set("permissions", perms)
 		default:
-			block[repo] = map[string]interface{}{
-				"permissions": map[string]interface{}{
-					"actions":   "write",
-					"contents":  "write",
-					"packages":  "read",
-					"workflows": "write",
-				},
-			}
+			perms := NewOrderedMap()
+			perms.Set("actions", "write")
+			perms.Set("contents", "write")
+			perms.Set("packages", "read")
+			perms.Set("workflows", "write")
+			repoPerms.Set("permissions", perms)
 		}
+		block.Set(repo, repoPerms)
 	}
 	return block
 }
 
 // mergeRepoPermissions drills into doc["customizations"]["codespaces"]["repositories"]
 // and merges reposBlock, creating intermediate maps as needed.
-func mergeRepoPermissions(doc map[string]interface{}, reposBlock map[string]interface{}) {
-	customizations, _ := doc["customizations"].(map[string]interface{})
+func mergeRepoPermissions(doc *OrderedMap, reposBlock *OrderedMap) {
+	var customizations *OrderedMap
+	if c, ok := doc.Get("customizations"); ok {
+		if co, ok := c.(*OrderedMap); ok {
+			customizations = co
+		}
+	}
 	if customizations == nil {
-		customizations = make(map[string]interface{})
-		doc["customizations"] = customizations
+		customizations = NewOrderedMap()
+		doc.Set("customizations", customizations)
 	}
 
-	codespaces, _ := customizations["codespaces"].(map[string]interface{})
+	var codespaces *OrderedMap
+	if c, ok := customizations.Get("codespaces"); ok {
+		if co, ok := c.(*OrderedMap); ok {
+			codespaces = co
+		}
+	}
 	if codespaces == nil {
-		codespaces = make(map[string]interface{})
-		customizations["codespaces"] = codespaces
+		codespaces = NewOrderedMap()
+		customizations.Set("codespaces", codespaces)
 	}
 
-	repositories, _ := codespaces["repositories"].(map[string]interface{})
+	var repositories *OrderedMap
+	if r, ok := codespaces.Get("repositories"); ok {
+		if ro, ok := r.(*OrderedMap); ok {
+			repositories = ro
+		}
+	}
 	if repositories == nil {
-		repositories = make(map[string]interface{})
-		codespaces["repositories"] = repositories
+		repositories = NewOrderedMap()
+		codespaces.Set("repositories", repositories)
 	}
 
-	for k, v := range reposBlock {
-		repositories[k] = v
+	for _, k := range reposBlock.Keys {
+		if v, ok := reposBlock.Get(k); ok {
+			repositories.Set(k, v)
+		}
 	}
 }
 
@@ -492,18 +506,25 @@ func validateDevcontainerRelPath(p string) error {
 func updateDevcontainerFile(path string, repos []string, permissions string, dryRun bool) error {
 	reposBlock := buildRepoPermissionsBlock(repos, permissions)
 
-	var doc map[string]interface{}
+	var doc *OrderedMap
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("reading %s: %w", path, err)
 		}
 		// File does not exist – start with an empty JSON object.
-		doc = make(map[string]interface{})
+		doc = NewOrderedMap()
 	} else {
 		clean := stripJSONC(data)
-		if err := json.Unmarshal(clean, &doc); err != nil {
+		dec := json.NewDecoder(bytes.NewReader(clean))
+		val, err := decodeValue(dec)
+		if err != nil {
 			return fmt.Errorf("parsing %s: %w", path, err)
+		}
+		var ok bool
+		doc, ok = val.(*OrderedMap)
+		if !ok {
+			return fmt.Errorf("parsing %s: root is not an object", path)
 		}
 	}
 

--- a/cmd/repos/codespaces_auth_test.go
+++ b/cmd/repos/codespaces_auth_test.go
@@ -196,42 +196,66 @@ func TestStripJSONC_PreservesCommasInStrings(t *testing.T) {
 
 func TestBuildRepoPermissionsBlock_Default(t *testing.T) {
 	block := buildRepoPermissionsBlock([]string{"acme/api"}, "default")
-	entry, ok := block["acme/api"].(map[string]interface{})
+	v, ok := block.Get("acme/api")
 	if !ok {
-		t.Fatalf("expected map entry for acme/api, got %T", block["acme/api"])
+		t.Fatalf("missing acme/api")
 	}
-	perms, ok := entry["permissions"].(map[string]interface{})
+	entry, ok := v.(*OrderedMap)
 	if !ok {
-		t.Fatalf("expected permissions map, got %T", entry["permissions"])
+		t.Fatalf("expected map entry for acme/api, got %T", v)
 	}
-	if perms["actions"] != "write" || perms["contents"] != "write" {
+	v, ok = entry.Get("permissions")
+	if !ok {
+		t.Fatalf("missing permissions")
+	}
+	perms, ok := v.(*OrderedMap)
+	if !ok {
+		t.Fatalf("expected permissions map, got %T", v)
+	}
+	a, _ := perms.Get("actions")
+	c, _ := perms.Get("contents")
+	if a != "write" || c != "write" {
 		t.Fatalf("unexpected default permissions: %v", perms)
 	}
 }
 
 func TestBuildRepoPermissionsBlock_All(t *testing.T) {
 	block := buildRepoPermissionsBlock([]string{"acme/api"}, "all")
-	entry, ok := block["acme/api"].(map[string]interface{})
+	v, ok := block.Get("acme/api")
 	if !ok {
-		t.Fatalf("expected map entry for acme/api, got %T", block["acme/api"])
+		t.Fatalf("missing acme/api")
 	}
-	if entry["permissions"] != "write-all" {
-		t.Fatalf("expected write-all, got %v", entry["permissions"])
+	entry, ok := v.(*OrderedMap)
+	if !ok {
+		t.Fatalf("expected map entry for acme/api, got %T", v)
+	}
+	p, _ := entry.Get("permissions")
+	if p != "write-all" {
+		t.Fatalf("expected write-all, got %v", p)
 	}
 }
 
 func TestBuildRepoPermissionsBlock_Contents(t *testing.T) {
 	block := buildRepoPermissionsBlock([]string{"acme/api"}, "contents")
-	entry, ok := block["acme/api"].(map[string]interface{})
+	v, ok := block.Get("acme/api")
 	if !ok {
-		t.Fatalf("expected map entry for acme/api, got %T", block["acme/api"])
+		t.Fatalf("missing acme/api")
 	}
-	perms, ok := entry["permissions"].(map[string]interface{})
+	entry, ok := v.(*OrderedMap)
 	if !ok {
-		t.Fatalf("expected permissions map, got %T", entry["permissions"])
+		t.Fatalf("expected map entry for acme/api, got %T", v)
 	}
-	if perms["contents"] != "write" {
-		t.Fatalf("expected contents:write, got %v", perms)
+	v, ok = entry.Get("permissions")
+	if !ok {
+		t.Fatalf("missing permissions")
+	}
+	perms, ok := v.(*OrderedMap)
+	if !ok {
+		t.Fatalf("expected permissions map, got %T", v)
+	}
+	c, _ := perms.Get("contents")
+	if c != "write" {
+		t.Fatalf("expected contents:write, got %v", c)
 	}
 }
 
@@ -247,46 +271,60 @@ func TestRunCodespacesAuth_InvalidPermissionsReturnsError(t *testing.T) {
 }
 
 func TestMergeRepoPermissions_CreatesNestedKeys(t *testing.T) {
-	doc := make(map[string]interface{})
+	doc := NewOrderedMap()
 	block := buildRepoPermissionsBlock([]string{"acme/api"}, "default")
 	mergeRepoPermissions(doc, block)
 
-	custom, ok := doc["customizations"].(map[string]interface{})
+	v, ok := doc.Get("customizations")
 	if !ok {
 		t.Fatalf("customizations not created")
 	}
-	cs, ok := custom["codespaces"].(map[string]interface{})
+	custom, ok := v.(*OrderedMap)
+	if !ok {
+		t.Fatalf("customizations is not an ordered map")
+	}
+	v, ok = custom.Get("codespaces")
 	if !ok {
 		t.Fatalf("codespaces not created")
 	}
-	repos, ok := cs["repositories"].(map[string]interface{})
+	cs, ok := v.(*OrderedMap)
+	if !ok {
+		t.Fatalf("codespaces is not an ordered map")
+	}
+	v, ok = cs.Get("repositories")
 	if !ok {
 		t.Fatalf("repositories not created")
 	}
-	if _, ok := repos["acme/api"]; !ok {
+	repos, ok := v.(*OrderedMap)
+	if !ok {
+		t.Fatalf("repositories is not an ordered map")
+	}
+	if _, ok := repos.Get("acme/api"); !ok {
 		t.Fatalf("acme/api not found in repositories")
 	}
 }
 
 func TestMergeRepoPermissions_MergesIntoExisting(t *testing.T) {
-	doc := map[string]interface{}{
-		"customizations": map[string]interface{}{
-			"codespaces": map[string]interface{}{
-				"repositories": map[string]interface{}{
-					"existing/repo": map[string]interface{}{},
-				},
-			},
-		},
-	}
+	doc := NewOrderedMap()
+	custom := NewOrderedMap()
+	codespaces := NewOrderedMap()
+	repos := NewOrderedMap()
+	repos.Set("existing/repo", NewOrderedMap())
+	codespaces.Set("repositories", repos)
+	custom.Set("codespaces", codespaces)
+	doc.Set("customizations", custom)
+
 	block := buildRepoPermissionsBlock([]string{"acme/new"}, "default")
 	mergeRepoPermissions(doc, block)
 
-	cs := doc["customizations"].(map[string]interface{})["codespaces"].(map[string]interface{})
-	repos := cs["repositories"].(map[string]interface{})
-	if _, ok := repos["existing/repo"]; !ok {
+	v1, _ := doc.Get("customizations")
+	v2, _ := v1.(*OrderedMap).Get("codespaces")
+	v3, _ := v2.(*OrderedMap).Get("repositories")
+	repoMap := v3.(*OrderedMap)
+	if _, ok := repoMap.Get("existing/repo"); !ok {
 		t.Fatalf("existing/repo was removed")
 	}
-	if _, ok := repos["acme/new"]; !ok {
+	if _, ok := repoMap.Get("acme/new"); !ok {
 		t.Fatalf("acme/new was not added")
 	}
 }

--- a/cmd/repos/ordered_map.go
+++ b/cmd/repos/ordered_map.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// OrderedMap preserves the order of keys when decoding and encoding JSON.
+type OrderedMap struct {
+	Keys []string
+	Vals map[string]any
+}
+
+func NewOrderedMap() *OrderedMap {
+	return &OrderedMap{
+		Keys: make([]string, 0),
+		Vals: make(map[string]any),
+	}
+}
+
+func (m *OrderedMap) Get(key string) (any, bool) {
+	val, ok := m.Vals[key]
+	return val, ok
+}
+
+func (m *OrderedMap) Set(key string, val any) {
+	if _, ok := m.Vals[key]; !ok {
+		m.Keys = append(m.Keys, key)
+	}
+	if m.Vals == nil {
+		m.Vals = make(map[string]any)
+	}
+	m.Vals[key] = val
+}
+
+func (m *OrderedMap) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	buf.WriteByte('{')
+	for i, k := range m.Keys {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		kb, err := json.Marshal(k)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(kb)
+		buf.WriteByte(':')
+		vb, err := json.Marshal(m.Vals[k])
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(vb)
+	}
+	buf.WriteByte('}')
+	return buf.Bytes(), nil
+}
+
+// decodeValue parses a JSON token stream, preserving object order into OrderedMap.
+func decodeValue(dec *json.Decoder) (any, error) {
+	t, err := dec.Token()
+	if err != nil {
+		if err == io.EOF {
+			return nil, nil
+		}
+		return nil, err
+	}
+	switch v := t.(type) {
+	case json.Delim:
+		if v == '{' {
+			return decodeObject(dec)
+		} else if v == '[' {
+			return decodeArray(dec)
+		}
+		return nil, fmt.Errorf("unexpected delim %v", v)
+	default:
+		return v, nil
+	}
+}
+
+func decodeObject(dec *json.Decoder) (*OrderedMap, error) {
+	m := NewOrderedMap()
+	for dec.More() {
+		t, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		key, ok := t.(string)
+		if !ok {
+			return nil, fmt.Errorf("expected string key, got %T", t)
+		}
+		val, err := decodeValue(dec)
+		if err != nil {
+			return nil, err
+		}
+		m.Set(key, val)
+	}
+	// consume '}'
+	_, err := dec.Token()
+	return m, err
+}
+
+func decodeArray(dec *json.Decoder) ([]any, error) {
+	var arr []any
+	for dec.More() {
+		val, err := decodeValue(dec)
+		if err != nil {
+			return nil, err
+		}
+		arr = append(arr, val)
+	}
+	// consume ']'
+	_, err := dec.Token()
+	return arr, err
+}

--- a/cmd/repos/ordered_map_test.go
+++ b/cmd/repos/ordered_map_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestOrderedMap(t *testing.T) {
+	in := `{"image": "ghcr.io/m", "customizations": {"codespaces": {"repositories": {}}, "vscode": {}}}`
+	dec := json.NewDecoder(strings.NewReader(in))
+	dec.UseNumber()
+	val, err := decodeValue(dec)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := json.MarshalIndent(val, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := `{
+  "image": "ghcr.io/m",
+  "customizations": {
+    "codespaces": {
+      "repositories": {}
+    },
+    "vscode": {}
+  }
+}`
+	if string(out) != expected {
+		t.Errorf("expected:\n%s\ngot:\n%s", expected, string(out))
+	}
+}


### PR DESCRIPTION
Ensures that updating `devcontainer.json` files with `repos codespaces` preserves the original JSON key ordering by introducing an `OrderedMap` struct and modifying the decoding/encoding logic. Also verifies that all auth-related prompts are not present in the current codebase.

---
*PR created automatically by Jules for task [10213953709204952058](https://jules.google.com/task/10213953709204952058) started by @MiguelRodo*