### PR TITLE
Docs: Ensure inline CLI docs and website are up to date

### DIFF
--- a/clone.qmd
+++ b/clone.qmd
@@ -25,6 +25,8 @@ repos clone
 | `--depth <n>` | Opt-in shallow clone depth (must be a positive integer) |
 | `--force` | Ignore per-line flag overrides and enforce CLI flags |
 | `--create` | Create and push missing branches referenced in `repos.list` |
+| `--debug` | Enable debug output to stderr |
+| `--debug-file [file]` | Enable debug output to file (auto-generate temp if no path given) |
 
 ```bash
 # Use a custom list file

--- a/pipelines.qmd
+++ b/pipelines.qmd
@@ -34,6 +34,8 @@ either `renv.lock` or `DESCRIPTION`.
 | `--exclude <repos>` | Comma-separated list of repositories to skip |
 | `--continue-on-error` | Keep running even if a repository fails |
 | `--dry-run` | Print what would be run without executing anything |
+| `--debug` | Enable debug output to stderr |
+| `--debug-file [file]` | Enable debug output to file (auto-generate temp if no path given) |
 | `--ensure-setup` | Clone repositories before running the pipeline |
 | `--skip-deps` | Skip the default `install-r-deps` setup step |
 | `--verbose` | Enable verbose logging |

--- a/vscode.qmd
+++ b/vscode.qmd
@@ -32,6 +32,8 @@ positron entire-project.code-workspace  # Positron
 | Flag | Description |
 |---|---|
 | `-f <file>` | Use a different list file (default: `repos.list`) |
+| `--debug` | Enable debug output to stderr |
+| `--debug-file [file]` | Enable debug output to file (auto-generate temp if no path given) |
 
 ```bash
 # Use a custom list file
@@ -69,6 +71,8 @@ repos codespace
 | `--all` | Update all `devcontainer.json` files found under `.devcontainer/` |
 | `--permissions <level>` | Codespaces permission level (`default`, `all`, or `contents`) |
 | `--dry-run` | Preview file updates without writing changes |
+| `--debug` | Enable debug output to stderr |
+| `--debug-file [file]` | Enable debug output to file (auto-generate temp if no path given) |
 
 Permission levels:
 


### PR DESCRIPTION
Ensure in-line cli documentation and the website are both up to date by synchronizing missing `--debug` flags.

---
*PR created automatically by Jules for task [2122653644364838656](https://jules.google.com/task/2122653644364838656) started by @MiguelRodo*